### PR TITLE
[INJIMOB-812] - Change swift tools version to 5.9.0 to build in xcode 15.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9.0
 
 import PackageDescription
 


### PR DESCRIPTION
Might need to upgrade the mac os runner to latest one which has latest Xcode and Swift versions.