### PR TITLE
[INJIMOB-3226] populate context and send response in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,8 @@ await openID4VP.sendErrorToVerifier(error: AuthorizationConsent.consentRejectedE
 ## Architecture decisions
 
 Architecture decisions are noted as ADRs [here](https://github.com/mosip/inji-openid4vp/tree/master/doc).
+
+## Also available in
+
+This library is also available in the following languages
+- [kotlin](https://github.com/mosip/inji-openid4vp/tree/master/kotlin)

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ This method will also notify the Verifier about the error by sending it to the r
 
 ###### Parameters
 
-| Name           | Type               | Description                                                                                                                                    |
-|----------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| credentialsMap | [String: [String]] | A Map which contains input descriptor id as key and value is the map of credential format and the list of user selected verifiable credentials |
+| Name           | Type                               | Description                                                                                                                                    |
+|----------------|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialsMap | [String: [FormatType: Array<Any>]] | A Map which contains input descriptor id as key and value is the map of credential format and the list of user selected verifiable credentials |
 
 ###### Example usage
 
@@ -194,7 +194,8 @@ This method will also notify the Verifier about the error by sending it to the r
 let unsignedVPTokens: [FormatType: UnsignedVPToken] = try openID4VP.constructUnsignedVPToken(
     credentialsMap: [
         "input_descriptor_id": [
-            FormatType.LDP_VC.rawValue: ["credential1"]
+            FormatType.ldp_vc.rawValue: [["id": "uuid-1234-1234", //....]],
+            FormatType.mso_mdoc.rawValue: ["<base64-encoded-cbor-encoded-credential>"]
         ]
     ]
 )
@@ -217,8 +218,8 @@ This method will also notify the Verifier about the error by sending it to the r
 
 ###### Parameters
 
-| Name                | Type                             | Description                                                                                                                                                 |
-|---------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name                  | Type                               | Description                                                                                                                                                   |
+|-----------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | vpTokenSigningResults | [FormatType: VPTokenSigningResult] | This will be a map with key as credential format and value as VPTokenSigningResult (which is specific to respective credential format's required information) |
 
 
@@ -226,12 +227,21 @@ This method will also notify the Verifier about the error by sending it to the r
 
 ```swift
 let ldpVPTokenSigningResult = LdpVPTokenSigningResult(
-    jws : "ey....qweug",
+    jws : createJWS(unsignedLdpVPToken),
     signatureAlgorithm : "RsaSignature2018",
-    publicKey : publicKey,
+    publicKey : "<publicKey>",
     domain : "<domain>"
 )
-let vpTokenSigningResults : [FormatType: VPTokenSigningResult] = [FormatType.LDP_VC : ldpVPTokenSigningResult]
+
+let mdocVPTokenSigningResult = MdocVPTokenSigningResult(
+    docTypeToDeviceAuthentication: [
+        "<docType>": DeviceAuthentication(
+            signature: createSignature(unsignedMdocVPToken.docTypeToDeviceAuthenticationBytes("<docType>")), 
+            algorithm: "<mdocAuthenticationAlgorithm>",
+        )
+    ]
+  )
+let vpTokenSigningResults : [FormatType: VPTokenSigningResult] = [FormatType.ldp_vc : ldpVPTokenSigningResult, FormatType.mso_mdoc: mdocVPTokenSigningResult]
 val response : String = try await openID4VP.shareVerifiablePresentation(vpTokenSigningResults : vpTokenSigningResults)
 ```
 

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponse.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponse.swift
@@ -5,13 +5,11 @@ struct AuthorizationResponse {
     let presentation_submission: PresentationSubmission
     let state: String?
     static let className = String(describing: AuthorizationResponse.self)
-
-    func toJsonEncodedMap() throws -> [String: String] {
-        let encodedVPTokenData =  vpToken.encoded ?? ""
-        let encodedPresentationSubmission = try encode(self.presentation_submission, fieldName: "presentation_submission", className: AuthorizationResponse.className)
-        var bodyParams: [String: String] = [
-            "vp_token": encodedVPTokenData,
-            "presentation_submission": encodedPresentationSubmission
+    
+    func toJsonEncodedMap() throws -> [String: Any] {
+        var bodyParams : [String: Any] = [
+            "vp_token": self.vpToken.encoded ?? [:],
+            "presentation_submission": try self.presentation_submission.jsonData()
         ]
         
         if let state = state {
@@ -25,7 +23,7 @@ struct AuthorizationResponse {
 public enum VPTokenType {
     case vpTokenArray([VPToken])
     case vpTokenElement(VPToken)
-
+    
     enum CodingKeys: String, CodingKey {
         case type
         case value
@@ -33,15 +31,15 @@ public enum VPTokenType {
 }
 
 extension VPTokenType {
-    var encoded: String? {
+    var encoded: Any? {
         do {
             switch self {
             case .vpTokenArray(let tokens):
-                let encodedTokens = try tokens.map { try encode($0, fieldName: "vpToken", className: AuthorizationResponse.className) }
-                return try encode(encodedTokens, fieldName: "vpTokenArray", className: AuthorizationResponse.className)
-
+                let encodedTokens = try tokens.map { try $0.jsonData() }
+                return encodedTokens
+                
             case .vpTokenElement(let token):
-                let encodedToken = try encode(token, fieldName: "vpTokenElement", className: AuthorizationResponse.className)
+                let encodedToken = try token.jsonData()
                 return encodedToken
             }
         } catch {
@@ -50,3 +48,14 @@ extension VPTokenType {
     }
 }
 
+extension Encodable {
+    func jsonData() throws -> Any {
+        JSON.encoder.outputFormatting = [ .withoutEscapingSlashes]
+        return try JSONSerialization.jsonObject(with: JSON.encoder.encode(self))
+    }
+}
+
+struct JSON {
+    // add pretty printed option
+    static let encoder = JSONEncoder()
+}

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponse.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponse.swift
@@ -2,14 +2,14 @@ import Foundation
 
 struct AuthorizationResponse {
     let vpToken: VPTokenType
-    let presentation_submission: PresentationSubmission
+    let presentationSubmission: PresentationSubmission
     let state: String?
     static let className = String(describing: AuthorizationResponse.self)
     
     func toJsonEncodedMap() throws -> [String: Any] {
         var bodyParams : [String: Any] = [
             "vp_token": self.vpToken.encoded ?? [:],
-            "presentation_submission": try self.presentation_submission.jsonData()
+            "presentation_submission": try self.presentationSubmission.jsonData()
         ]
         
         if let state = state {
@@ -46,16 +46,4 @@ extension VPTokenType {
             return nil
         }
     }
-}
-
-extension Encodable {
-    func jsonData() throws -> Any {
-        JSON.encoder.outputFormatting = [ .withoutEscapingSlashes]
-        return try JSONSerialization.jsonObject(with: JSON.encoder.encode(self))
-    }
-}
-
-struct JSON {
-    // add pretty printed option
-    static let encoder = JSONEncoder()
 }

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -71,8 +71,7 @@ public class AuthorizationResponseHandler {
     }
     
     //Send authorization response based on response_mode
-    private func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest ,authorizationResponse: AuthorizationResponse, responseUri: String, producerInfo: String,
-                                           recepientInfo: String) async throws -> String {
+    private func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest ,authorizationResponse: AuthorizationResponse, responseUri: String, producerInfo: String, recepientInfo: String) async throws -> String {
         return try await ResponseModeBasedHandlerFactory.get(responseMode: authorizationRequest.responseMode)
             .sendAuthorizationResponse(authorizationRequest: authorizationRequest, authorizationResponse: authorizationResponse, url: responseUri, networkManager: networkManager, producerInfo: producerInfo, recepientInfo: recepientInfo)
     }
@@ -93,15 +92,15 @@ public class AuthorizationResponseHandler {
             switch format {
             case .ldp_vc:
                 let formattedCredentials = try credentials.map { credential -> [String: Any] in
-                                guard let jsonDict = credential as? [String: Any] else {
-                                    throw Logger.handleException(
-                                        exceptionType: "InvalidData",
-                                        message: "\(format) credentials are not passed in JSON format",
-                                        className: AuthorizationResponseHandler.className
-                                    )
-                                }
-                                return jsonDict
-                            }
+                    guard let jsonDict = credential as? [String: Any] else {
+                        throw Logger.handleException(
+                            exceptionType: "InvalidData",
+                            message: "\(format) credentials are not passed in JSON format",
+                            className: AuthorizationResponseHandler.className
+                        )
+                    }
+                    return jsonDict
+                }
                 result[format] = try UnsignedLdpVPTokenBuilder(verifiableCredential: formattedCredentials, id: UUIDGenerator.generateUUID(), holder: "").build()
             case .mso_mdoc:
                 guard let stringCredentials = credentials as? [String] else {
@@ -121,7 +120,7 @@ public class AuthorizationResponseHandler {
         credentialFormatIndex: inout [FormatType: Int]
     ) throws -> VPTokenType {
         var vpTokens: [VPToken] = []
-                
+        
         // create an map of credential format to credentials from credentialsMap
         let groupedVcs: [FormatType: [Any]] = credentialsMap?
             .compactMap { $0.value }

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -92,13 +92,17 @@ public class AuthorizationResponseHandler {
             let (format, credentials) = entry
             switch format {
             case .ldp_vc:
-                guard let stringCredentials = credentials as? [String] else {
-                    throw Logger.handleException(
-                        exceptionType : "InvalidData",
-                        message : "\(format) credentials are not passed in string format", className : AuthorizationResponseHandler.className
-                    )
-                }
-                result[format] = try UnsignedLdpVPTokenBuilder(verifiableCredential: stringCredentials, id: UUIDGenerator.generateUUID(), holder: "").build()
+                let formattedCredentials = try credentials.map { credential -> [String: Any] in
+                                guard let jsonDict = credential as? [String: Any] else {
+                                    throw Logger.handleException(
+                                        exceptionType: "InvalidData",
+                                        message: "\(format) credentials are not passed in JSON format",
+                                        className: AuthorizationResponseHandler.className
+                                    )
+                                }
+                                return jsonDict
+                            }
+                result[format] = try UnsignedLdpVPTokenBuilder(verifiableCredential: formattedCredentials, id: UUIDGenerator.generateUUID(), holder: "").build()
             case .mso_mdoc:
                 guard let stringCredentials = credentials as? [String] else {
                     throw Logger.handleException(

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -64,7 +64,7 @@ public class AuthorizationResponseHandler {
                 credentialFormatIndex: &credentialFormatIndex
             )
             
-            return AuthorizationResponse(vpToken: vpToken, presentation_submission: presentationSubmission, state: authorizationRequest.state)
+            return AuthorizationResponse(vpToken: vpToken, presentationSubmission: presentationSubmission, state: authorizationRequest.state)
         default:
             throw Logger.handleException(exceptionType: "InvalidData", message: "response type - \(authorizationRequest.responseType) is not supported", className: AuthorizationResponseHandler.className)
         }

--- a/Sources/OpenID4VP/AuthorizationResponse/Models/PresentationSubmission.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/Models/PresentationSubmission.swift
@@ -18,7 +18,6 @@ struct PathNested : Encodable {
     let path: String
 }
 
-//TODO: use coding keys to handle modification of field names
 struct PresentationSubmission: Encodable{
     let id: String = UUIDGenerator.generateUUID()
     let definitionId: String

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPToken.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPToken.swift
@@ -1,7 +1,7 @@
 public struct UnsignedLdpVPToken: Codable, UnsignedVPToken {
     let context: [String]
     let type: [String]
-    let verifiableCredential: [String]
+    let verifiableCredential: [[String: AnyCodable]]
     let id: String
     let holder: String
 

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPTokenBuilder.swift
@@ -17,8 +17,10 @@ struct UnsignedLdpVPTokenBuilder: UnsignedVPTokenBuilder {
         //and add it to the context
         var context = Set<String>()
         self.verifiableCredential.forEach { credential in
-            if let contextValue = credential["@context"] as? [String] {
-                context.insert(contextValue[0])
+            // @context property is an ordered set of type URL (or URI in Data model v1) or objects
+            // The base context is the first entry in the set which is VC context URL (or URI in Data model v1)
+            if let contextArray = credential["@context"] as? [Any], let contextValue = contextArray.first as? String {
+                context.insert(contextValue)
             }
         }
         

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPTokenBuilder.swift
@@ -1,9 +1,9 @@
 struct UnsignedLdpVPTokenBuilder: UnsignedVPTokenBuilder {
-    private let verifiableCredential: [String]
+    private let verifiableCredential: [[String: Any]]
     private let id: String
     private let holder: String
     
-    init( verifiableCredential: [String],
+    init( verifiableCredential: [[String: Any]],
           id: String,
           holder: String) {
         self.verifiableCredential = verifiableCredential
@@ -13,11 +13,18 @@ struct UnsignedLdpVPTokenBuilder: UnsignedVPTokenBuilder {
     
     func build() throws -> UnsignedVPToken {
         //parse the verifiableCredential array
-        //get the @context property from each verifiableCredential
-        //and add it to the context array
-        return UnsignedLdpVPToken(context : ["https://www.w3.org/2018/credentials/v1"],
+        //get the @context property's first entry from each verifiableCredential
+        //and add it to the context
+        var context = Set<String>()
+        self.verifiableCredential.forEach { credential in
+            if let contextValue = credential["@context"] as? [String] {
+                context.insert(contextValue[0])
+            }
+        }
+        
+        return UnsignedLdpVPToken(context : Array(context),
                                   type : ["VerifiablePresentation"],
-                                  verifiableCredential: self.verifiableCredential,
+                                  verifiableCredential: self.verifiableCredential.map { $0.mapValues { AnyCodable($0) } },
                                   id: self.id,
                                   holder: self.holder)
     }

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/Mdoc/UnsignedMdocVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/Mdoc/UnsignedMdocVPTokenBuilder.swift
@@ -21,9 +21,9 @@ struct UnsignedMdocVPTokenBuilder: UnsignedVPTokenBuilder {
     func build() throws ->  UnsignedVPToken {
         var docTypeToDeviceAuthenticationBytes : [String : String] = [:]
         let clientIdToHash = CBOR.array([.utf8String(clientId), .utf8String(self.mdocGeneratedNonce)])
-        let clientIdHash = CBOR.byteString(SHA256Hash(from: clientIdToHash))
+        let clientIdHash = CBOR.byteString(sha256Hash(from: clientIdToHash))
         let responseUriToHash = CBOR.array([.utf8String(responseUri), .utf8String(self.mdocGeneratedNonce)])
-        let responseUriHash = CBOR.byteString(SHA256Hash(from: responseUriToHash))
+        let responseUriHash = CBOR.byteString(sha256Hash(from: responseUriToHash))
         
         let openID4VPHandover = CBOR.array([clientIdHash, responseUriHash, .utf8String(self.mdocGeneratedNonce)])
         let sessionTranscript = CBOR.array([.null, .null, openID4VPHandover])

--- a/Sources/OpenID4VP/AuthorizationResponse/VPToken/types/LdpVp/LdpVPToken.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/VPToken/types/LdpVp/LdpVPToken.swift
@@ -1,7 +1,7 @@
 struct LdpVPToken: Encodable, VPToken {
     let context: [String]
     let type: [String]
-    let verifiableCredential: [String]
+    let verifiableCredential: [[String: AnyCodable]]
     let id: String
     let holder: String
     let proof: Proof

--- a/Sources/OpenID4VP/Common/AnyCodable.swift
+++ b/Sources/OpenID4VP/Common/AnyCodable.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+ public struct AnyCodable: Codable {
+    public var value: Any
+     static let className = String(describing: AnyCodable.self)
+    
+    init(_ value: Any) {
+        self.value = value
+    }
+    
+     public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let double = try? container.decode(Double.self) {
+            value = double
+        } else if let string = try? container.decode(String.self) {
+            value = string
+        } else if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let nestedDict = try? container.decode([String: AnyCodable].self) {
+            value = nestedDict.mapValues { $0.value }
+        } else if let nestedArray = try? container.decode([AnyCodable].self) {
+            value = nestedArray.map { $0.value }
+        } else if container.decodeNil() {
+            value = Optional<Any>.none as Any
+        } else {
+            throw Logger.handleException(exceptionType: "Decoding", message: "Error occured while decoding response", className: AnyCodable.className)
+        }
+    }
+    
+     public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        if let int = value as? Int {
+            try container.encode(int)
+        } else if let double = value as? Double {
+            try container.encode(double)
+        } else if let string = value as? String {
+            try container.encode(string)
+        } else if let bool = value as? Bool {
+            try container.encode(bool)
+        } else if let nestedDict = value as? [String: Any] {
+            try container.encode(nestedDict.mapValues { AnyCodable($0) })
+        } else if let nestedArray = value as? [Any] {
+            try container.encode(nestedArray.map { AnyCodable($0) })
+        } else {
+            throw Logger.handleException(exceptionType: "JsonEncodingFailed", message: "Error occured while encoding response", className: AnyCodable.className)
+        }
+    }
+}

--- a/Sources/OpenID4VP/Common/FieldValidator.swift
+++ b/Sources/OpenID4VP/Common/FieldValidator.swift
@@ -9,8 +9,7 @@ func isValidString(_ field: String) -> Bool {
 }
 
 func validateField<T>(field: T, fieldPath: [String], className: String) throws {
-    switch field {
-    case let stringValue as String:
+    if let stringValue = field as? String {
         if !isValidString(stringValue) {
             throw Logger.handleException(
                 exceptionType: "InvalidInput",
@@ -18,7 +17,5 @@ func validateField<T>(field: T, fieldPath: [String], className: String) throws {
                 className: className
             )
         }
-    default:
-        break
     }
 }

--- a/Sources/OpenID4VP/Common/JSONEncoder.swift
+++ b/Sources/OpenID4VP/Common/JSONEncoder.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct JSON {
+    // Create JSON encoder with custom settings - without escaping slashes
+    static let encoder = JSONEncoder()
+}
+
 extension Encodable {
     func jsonData() throws -> Any {
         JSON.encoder.outputFormatting = [ .withoutEscapingSlashes]
@@ -7,6 +12,18 @@ extension Encodable {
     }
 }
 
-struct JSON {
-    static let encoder = JSONEncoder()
+func encode<T: Encodable>(_ data: T, fieldName: String, className: String) throws -> String {
+    do {
+        let encoder = JSON.encoder
+        encoder.outputFormatting = .withoutEscapingSlashes
+        let jsonData = try encoder.encode(data)
+        return String(decoding: jsonData, as: UTF8.self)
+    } catch {
+        throw Logger.handleException(
+            exceptionType: "JsonEncodingFailed",
+            message: error.localizedDescription,
+            fieldPath: [fieldName],
+            className: className
+        )
+    }
 }

--- a/Sources/OpenID4VP/Common/JSONEncoder.swift
+++ b/Sources/OpenID4VP/Common/JSONEncoder.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Encodable {
+    func jsonData() throws -> Any {
+        JSON.encoder.outputFormatting = [ .withoutEscapingSlashes]
+        return try JSONSerialization.jsonObject(with: JSON.encoder.encode(self))
+    }
+}
+
+struct JSON {
+    static let encoder = JSONEncoder()
+}

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -113,7 +113,7 @@ func createNonce(entropy: Int = 16) -> String {
     return Base64Encoder.encodeToBase64Url(randomData)
 }
 
-func SHA256Hash(from data: CBOR) -> [UInt8] {
+func sha256Hash(from data: CBOR) -> [UInt8] {
     let hash: SHA256.Digest = SHA256.hash(data: CBOR.encode(data))
     return ([UInt8])(Data(hash))
 }

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -62,22 +62,6 @@ func convertToInstance<T: Decodable>(_ input: String, as type: T.Type, fieldPath
     return try jsonData.toInstance(as: T.self)
 }
 
-func encode<T: Encodable>(_ data: T, fieldName: String, className: String) throws -> String {
-    do {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .withoutEscapingSlashes
-        let jsonData = try encoder.encode(data)
-        return String(decoding: jsonData, as: UTF8.self)
-    } catch {
-        throw Logger.handleException(
-            exceptionType: "JsonEncodingFailed",
-            message: error.localizedDescription,
-            fieldPath: [fieldName],
-            className: className
-        )
-    }
-}
-
 func toData(_ input: [String: Any]) throws -> Data {
     var processedInput: [String: Any] = [:]
 

--- a/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
@@ -1,22 +1,19 @@
 import Foundation
 import Alamofire
 
-public protocol NetworkManaging {
-    func sendHTTPRequest(url: String, method: HttpMethod, bodyParams: [String:String]?, headers: [String: String]?) async throws -> (responseBody: String, httpUrlResponse: HTTPURLResponse)
-}
-
 public struct NetworkManager: NetworkManaging {
     public static var shared = NetworkManager()
     static let logTag = Logger.getLogTag(String(describing: NetworkManager.self))
-
-    public func sendHTTPRequest(url: String, method: HttpMethod, bodyParams requestBody: [String:String]? = nil, headers: [String : String]? = nil) async throws -> (responseBody: String, httpUrlResponse: HTTPURLResponse) {
+    
+    public func sendHTTPRequest(url: String, method: HttpMethod, bodyParams requestBody: [String:Any]? = nil, headers: [String : String]? = nil) async throws -> (responseBody: String, httpUrlResponse: HTTPURLResponse) {
         let requestHeaders: HTTPHeaders? = headers?.reduce(into: HTTPHeaders()) { result, header in
             result.add(name: header.key, value: header.value)
         }
-        let encoding = getEncoding(for: headers?[Header.contentType.rawValue])
+        let contentType = headers?[Header.contentType.rawValue]
+        let encoding = getEncoding(for: contentType)
         
         return try await withCheckedThrowingContinuation { continuation in
-            AF.request(url, method: method, parameters: requestBody, encoding: encoding, headers: requestHeaders)
+            AF.request(url, method: method, parameters: formatRequestBody(requestBody, for: contentType), encoding: encoding, headers: requestHeaders)
                 .validate()
                 .responseString { response in
                     switch response.result {
@@ -44,13 +41,56 @@ public struct NetworkManager: NetworkManaging {
     }
     
     private func getEncoding(for contentType: String?) -> ParameterEncoding {
-        switch contentType {
-        case ContentTypes.applicationJson.rawValue:
+        if contentType == ContentTypes.applicationJson.rawValue {
             return JSONEncoding.default
-        case ContentTypes.applicationFormUrlEncoded.rawValue:
-            return URLEncoding.default
-        default:
+        } else {
             return URLEncoding.default
         }
     }
+    
+    private func formatRequestBody(_ body: [String: Any]?, for contentType: String?) -> Parameters {
+        guard let body = body else { return [:] }
+        
+        if contentType == ContentTypes.applicationJson.rawValue {
+            return body
+        } else {
+            return flattenFormURLEncoded(body)
+        }
+    }
+    
+    private func flattenFormURLEncoded(_ input: [String: Any]?) -> [String: String] {
+        var result: [String: String] = [:]
+        
+        func recurse(prefix: String, value: Any) {
+            switch value {
+            case let dict as [String: Any]:
+                for (key, nestedValue) in dict {
+                    let newPrefix = "\(prefix)[\(key)]"
+                    recurse(prefix: newPrefix, value: nestedValue)
+                }
+                
+            case let array as [Any]:
+                for (index, item) in array.enumerated() {
+                    let newPrefix = "\(prefix)[\(index)]"
+                    recurse(prefix: newPrefix, value: item)
+                }
+                
+            case let str as String:
+                result[prefix] = str
+                
+            case let number as NSNumber:
+                result[prefix] = number.stringValue
+                
+            default:
+                result[prefix] = "\(value)"
+            }
+        }
+        
+        for (key, value) in input ?? [:] {
+            recurse(prefix: key, value: value)
+        }
+        
+        return result
+    }
+    
 }

--- a/Sources/OpenID4VP/NetworkManager/NetworkManaging.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManaging.swift
@@ -1,11 +1,3 @@
-//
-//  NetworkManaging.swift
-//  OpenID4VP
-//
-//  Created by Kiruthika Jeyashankar on 13/05/25.
-//
-
-
 import Foundation
 import Alamofire
 

--- a/Sources/OpenID4VP/NetworkManager/NetworkManaging.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManaging.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkManaging.swift
+//  OpenID4VP
+//
+//  Created by Kiruthika Jeyashankar on 13/05/25.
+//
+
+
+import Foundation
+import Alamofire
+
+public protocol NetworkManaging {
+    func sendHTTPRequest(url: String, method: HttpMethod, bodyParams: [String:Any]?, headers: [String: String]?) async throws -> (responseBody: String, httpUrlResponse: HTTPURLResponse)
+}

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -8,7 +8,7 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
     }
     
     func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest, authorizationResponse: AuthorizationResponse, url: String, networkManager: any NetworkManaging, producerInfo: String, recepientInfo: String) async throws -> String {
-        let requestBody: [String: String] = try authorizationResponse.toJsonEncodedMap()
+        let requestBody: [String: Any] = try authorizationResponse.toJsonEncodedMap()
         
         let response = try await networkManager.sendHTTPRequest(url: url, method: .post, bodyParams: requestBody, headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue])
         

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
@@ -17,7 +17,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     
     func setup(){
         super.setUp()
-        mockNetworkManager.clearMockResponses()
+        mockNetworkManager.clearResponses()
     }
     
     //Fetch authorization request

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -56,7 +56,10 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
       ],
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
+        "https://www.w3.org/2018/credentials/examples/v1",
+        {
+          "sec": "https://w3id.org/security#"
+        }
       ],
       "issuer": {
         "id": "did:example:issuer"
@@ -95,7 +98,10 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
       ],
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
+        "https://www.w3.org/2018/credentials/examples/v1",
+        {
+          "sec": "https://w3id.org/security#"
+        }
       ]
     },
     {
@@ -106,7 +112,10 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
       },
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
+        "https://www.w3.org/2018/credentials/examples/v1",
+        {
+          "sec": "https://w3id.org/security#"
+        }
       ],
       "issuer": {
         "id": "did:example:issuer"

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 final class AuthorizationResponseHandlerTests: XCTestCase {
     let mockNetworkManager = MockNetworkManager()
-    let verifiableCredentials: [String: [FormatType: [Any]]] = ["input_descriptor1": [.ldp_vc: ["cred1", "cred3"]], "input_descriptor2": [.ldp_vc: ["cred3"]]]
+    let verifiableCredentials: [String: [FormatType: [Any]]] = ["input_descriptor1": [.ldp_vc: [ldpVC(), ldpVC(credentialType: "UniversityCredential")]], "input_descriptor2": [.ldp_vc: [ldpVC()]]]
     let vpTokenSigningResults = [FormatType.ldp_vc:LdpVPTokenSigningResult(jws: "wemcn3234ns", signatureAlgorithm: "RsaSignature2018", publicKey: "-----BEGIN PUBLIC KEY-----\\nMIIBIjANBggvSPv73S\\nG5ToTt07NZPdKDrg9lSjetZup39oj12u0YoyRMlMhY0xYL6c8X1BexM7Wlp+c13o\\n1QIDAQAB\\n-----END PUBLIC KEY-----\\n", domain: "https://example")]
-    let unsignedVPTokens = [FormatType.ldp_vc: UnsignedLdpVPToken(context: ["https://www.w3.org/2018/credentials/v1"], type: ["VerifiablePresentation"], verifiableCredential: ["cred1","cred2", "cred3"], id: "uuid", holder: "wallet/app")]
+    let unsignedVPTokens = [FormatType.ldp_vc: UnsignedLdpVPToken(context: ["https://www.w3.org/2018/credentials/v1"], type: ["VerifiablePresentation"], verifiableCredential: [ldpVC().mapValues { AnyCodable($0) },ldpVC(credentialType: "UniversityCredential").mapValues { AnyCodable($0) }, ldpVC(credentialType: "DegreeCredential").mapValues { AnyCodable($0) }], id: "uuid", holder: "wallet/app")]
     
     /// construction of vp_token for signing
     
@@ -15,7 +15,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         
         XCTAssertTrue(vpTokens.keys.count == 1)
         let ldpVPToken = vpTokens[.ldp_vc] as! UnsignedLdpVPToken
-        XCTAssertEqual(ldpVPToken.verifiableCredential.count, ["cred1", "cred2", "cred3"].count)
+        XCTAssertEqual(ldpVPToken.verifiableCredential.count, 3)
         XCTAssertEqual(ldpVPToken.holder, "")
         XCTAssertEqual(ldpVPToken.type, ["VerifiablePresentation"])
         XCTAssertEqual(ldpVPToken.context, ["https://www.w3.org/2018/credentials/v1"])
@@ -31,9 +31,112 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         
     }
     
-    /// sharing of verifiable presentations
+    // Sharing of verifiable presentations
+    /// one VP format in response_type vp_token
     
-    func testShareVPHasThePresentationDefinitionAsExpected() async throws {
+    func testShareVPHasTheAuthorizationResponseAsExpected() async throws {
+        let expectedVPToken = """
+{
+  "type": [
+    "VerifiablePresentation"
+  ],
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "verifiableCredential": [
+    {
+      "credentialSubject": {
+        "family_name": "Mockister",
+        "given_name": "MockUser",
+        "birthdate": "1949-01-22"
+      },
+      "type": [
+        "VerifiableCredential",
+        "IDCardCredential"
+      ],
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
+      "issuer": {
+        "id": "did:example:issuer"
+      },
+      "proof": {
+        "jws": "eyJhb...JQdBw",
+        "created": "2021-03-19T15:30:15Z",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "did:example:issuer#keys-1",
+        "type": "Ed25519Signature2018"
+      },
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "id": "https://example.com/credentials/1872"
+    },
+    {
+      "id": "https://example.com/credentials/1872",
+      "issuer": {
+        "id": "did:example:issuer"
+      },
+      "proof": {
+        "verificationMethod": "did:example:issuer#keys-1",
+        "jws": "eyJhb...JQdBw",
+        "proofPurpose": "assertionMethod",
+        "created": "2021-03-19T15:30:15Z",
+        "type": "Ed25519Signature2018"
+      },
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "credentialSubject": {
+        "family_name": "Mockister",
+        "birthdate": "1949-01-22",
+        "given_name": "MockUser"
+      },
+      "type": [
+        "VerifiableCredential",
+        "UniversityCredential"
+      ],
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ]
+    },
+    {
+      "credentialSubject": {
+        "given_name": "MockUser",
+        "birthdate": "1949-01-22",
+        "family_name": "Mockister"
+      },
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
+      "issuer": {
+        "id": "did:example:issuer"
+      },
+      "type": [
+        "VerifiableCredential",
+        "IDCardCredential"
+      ],
+      "id": "https://example.com/credentials/1872",
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "proof": {
+        "jws": "eyJhb...JQdBw",
+        "verificationMethod": "did:example:issuer#keys-1",
+        "type": "Ed25519Signature2018",
+        "proofPurpose": "assertionMethod",
+        "created": "2021-03-19T15:30:15Z"
+      }
+    }
+  ],
+  "holder": "",
+  "proof": {
+    "challenge": "nonce",
+    "jws": "testJWS",
+    "domain": "testDomain",
+    "type": "ES256",
+    "verificationMethod": "testPublicKey",
+    "proofPurpose": "authentication",
+  }
+}
+"""
         let authorizationResponseHandler: AuthorizationResponseHandler = AuthorizationResponseHandler(networkManager: mockNetworkManager)
         _ = try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(),responseUri : "/response-uri")
         let responseUri = "https://mock-verifier.com"
@@ -53,16 +156,14 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let decodedPresentationSubmission = decodeQueryValue((recordedRequest.requestBody?["presentation_submission"])!)
         let decodedVPToken = decodeQueryValue((recordedRequest.requestBody?["vp_token"])!)
         XCTAssertTrue(recordedRequest.requestBody?.keys.count == 3)
-        assertJsonString(expected: "{\"definition_id\":\"vp_presentation_definition\",\"descriptor_map\":[{\"path_nested\":{\"path\":\"$.verifiableCredential[0]\",\"id\":\"input_descriptor1\",\"format\":\"ldp_vc\"},\"format\":\"ldp_vp\",\"id\":\"input_descriptor1\",\"path\":\"$\"},{\"format\":\"ldp_vp\",\"id\":\"input_descriptor1\",\"path_nested\":{\"id\":\"input_descriptor1\",\"format\":\"ldp_vc\",\"path\":\"$.verifiableCredential[1]\"},\"path\":\"$\"},{\"format\":\"ldp_vp\",\"id\":\"input_descriptor2\",\"path\":\"$\",\"path_nested\":{\"format\":\"ldp_vc\",\"path\":\"$.verifiableCredential[2]\",\"id\":\"input_descriptor2\"}}]}", actual: decodedPresentationSubmission, strict: false)
-        assertJsonString(expected: "{\r\n  \"proof\" : {\r\n    \"challenge\" : \"nonce\",\r\n    \"jws\" : \"testJWS\",\r\n    \"verificationMethod\" : \"testPublicKey\",\r\n    \"domain\" : \"testDomain\",\r\n    \"type\" : \"ES256\",\r\n    \"proofPurpose\" : \"authentication\"\r\n  },\r\n  \"type\" : [\r\n    \"VerifiablePresentation\"\r\n  ],\r\n  \"@context\" : [\r\n    \"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\"\r\n  ],\r\n  \"holder\" : \"\",\r\n  \"verifiableCredential\" : [\r\n    \"cred1\",\r\n    \"cred3\",\r\n    \"cred3\"\r\n  ]\r\n}", actual: decodedVPToken, strict: false)
+        assertJsonString(expected: expectedVPToken, actual: decodedVPToken, strict: false)
         XCTAssertEqual("state", recordedRequest.requestBody?["state"])
     }
     
-    ///// sharing of authorization response with more than one VP format in response_type vp_token
+    /// more than one VP format in response_type vp_token -> formats: ldp_vc, mso_mdoc
     func testShareVPSendingAuthorizationResponseWithMultipleVPFormatsSuccessfully() async throws {
-        //TODO: fix me :)
         let verifiableCredentials: [String: [FormatType: [Any]]] = [
-            "input_descriptor1": [.ldp_vc: ["cred3"]],
+            "input_descriptor1": [.ldp_vc: [ldpVC()]],
             "org.iso.18013.5.1.mDL": [.mso_mdoc: [sampleMdoc]]
         ]
         let authorizationResponseHandler: AuthorizationResponseHandler = AuthorizationResponseHandler(networkManager: mockNetworkManager)
@@ -86,7 +187,6 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         
         XCTAssertEqual("sending is success in AuthorizationResponseTests", result)
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
-        print("recordedRequest.requestBody: \(recordedRequest.requestBody)")
         XCTAssertTrue(recordedRequest.requestBody?.keys.count == 1)
         XCTAssertTrue(recordedRequest.requestBody?["response"] != nil)
         XCTAssertTrue(((recordedRequest.requestBody?["response"]?.starts(with: "ey")) != nil))
@@ -118,9 +218,9 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         }
     }
     
-    func testShareVPThrowErrorWhenVerifiableCredentialsAreNotPassedAsStringInLdpVcsOrMdocs() async  {
+    func testShareVPThrowErrorWhenVerifiableCredentialsAreNotPassedInExpectedFormats() async  {
         let testCases: [TestCase] = [
-            TestCase(input: ["input1": [FormatType.ldp_vc : [1,2]]], expectedError: "ldp_vc credentials are not passed in string format"),
+            TestCase(input: ["input1": [FormatType.ldp_vc : [1,2]]], expectedError: "ldp_vc credentials are not passed in JSON format"),
             TestCase(input: ["input1": [.mso_mdoc : [1,2]]], expectedError: "mso_mdoc credentials are not passed in string format"),
         ]
         let authorizationResponseHandler = AuthorizationResponseHandler(networkManager: mockNetworkManager)
@@ -130,57 +230,64 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             }
         }
     }
-}
-
-func jsonStringToArray(_ jsonString: String) -> [Any]? {
-    guard let data = jsonString.data(using: .utf8) else {
-        print("Failed to convert string to data")
-        return nil
-    }
     
-    do {
-        if let jsonArray = try JSONSerialization.jsonObject(with: data, options: []) as? [Any] {
-            return jsonArray
-        } else if let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-            // If it's an object rather than an array, wrap it in an array
-            return [jsonObject]
-        } else {
-            print("Failed to parse JSON into array or object")
-            return nil
-        }
-    } catch {
-        print("Error parsing JSON: \(error)")
-        return nil
+    /// construction of presentation submission for sharing
+    
+    /// format - ldp_vc
+    func testShareVPToSharePresentationSubmissionOfLdpVCInExpectedFormat() async throws {
+        let expectedPresentationSubmission = """
+{
+  "descriptor_map": [
+    {
+      "path": "$",
+      "path_nested": {
+        "id": "input_descriptor1",
+        "format": "ldp_vc",
+        "path": "$.verifiableCredential[0]"
+      },
+      "id": "input_descriptor1",
+      "format": "ldp_vp"
+    },
+    {
+      "path": "$",
+      "path_nested": {
+        "id": "input_descriptor1",
+        "path": "$.verifiableCredential[1]",
+        "format": "ldp_vc"
+      },
+      "id": "input_descriptor1",
+      "format": "ldp_vp"
+    },
+    {
+      "path": "$",
+      "path_nested": {
+        "format": "ldp_vc",
+        "path": "$.verifiableCredential[2]",
+        "id": "input_descriptor2"
+      },
+      "id": "input_descriptor2",
+      "format": "ldp_vp"
     }
+  ],
+  "definition_id": "vp_presentation_definition"
 }
-
-func stringToVPTokenArray(_ jsonString: String) -> VPTokenType? {
-    guard let data = jsonString.data(using: .utf8) else {
-        print("Failed to convert string to data")
-        return nil
-    }
-
-    do {
-        if let jsonArray = try JSONSerialization.jsonObject(with: data, options: []) as? [String] {
-            // Convert each string in the array to a VPToken
-            let vpTokens: [any VPToken] = jsonArray.map { MdocVPToken(value: $0) }
-            return .vpTokenArray(vpTokens)
-        } else if let jsonArray = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] {
-            // Handle array of objects by converting each to a token string representation
-            let vpTokens: [any VPToken] = jsonArray.compactMap { tokenObject in
-                if let tokenData = try? JSONSerialization.data(withJSONObject: tokenObject),
-                   let tokenString = String(data: tokenData, encoding: .utf8) {
-                    return MdocVPToken(value: tokenString)
-                }
-                return nil
-            }
-            return .vpTokenArray(vpTokens)
-        } else {
-            print("JSON string is not an array of strings or objects")
-            return nil
-        }
-    } catch {
-        print("Error parsing JSON string to VPTokenArray: \(error)")
-        return nil
+"""
+        let authorizationResponseHandler: AuthorizationResponseHandler = AuthorizationResponseHandler(networkManager: mockNetworkManager)
+        _ = try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(),responseUri : "/response-uri")
+        let responseUri = "https://mock-verifier.com"
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "sending is success in AuthorizationResponseTests")
+        let mockVPTokenSigningResults = [FormatType.ldp_vc : LdpVPTokenSigningResult(
+            jws: "testJWS",
+            signatureAlgorithm: "ES256",
+            publicKey: "testPublicKey",
+            domain: "testDomain"
+        )]
+        _ =  try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(), responseUri : "/response-uri")
+        
+        _ = try await authorizationResponseHandler.shareVP(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode, vpTokenSigningResults: mockVPTokenSigningResults, responseUri: responseUri)
+        
+        let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
+        let decodedPresentationSubmission = decodeQueryValue((recordedRequest.requestBody?["presentation_submission"])!)
+        assertJsonString(expected: expectedPresentationSubmission, actual: decodedPresentationSubmission, strict: false)
     }
 }

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -190,8 +190,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertTrue(recordedRequest.requestBody?.keys.count == 1)
         XCTAssertTrue(recordedRequest.requestBody?["response"] != nil)
-        //TODO: Cross check
-        XCTAssertTrue((((recordedRequest.requestBody?["response"] as! String).starts(with: "ey")) != nil))
+        XCTAssertTrue((recordedRequest.requestBody?["response"] as! String).starts(with: "ey"))
     }
     
     func testShareVPThrowErrorWhenResponseTypeIsNotSupportedByLibrary() async  {

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -138,8 +138,9 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
 }
 """
         let authorizationResponseHandler: AuthorizationResponseHandler = AuthorizationResponseHandler(networkManager: mockNetworkManager)
-        _ = try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(),responseUri : "/response-uri")
-        let responseUri = "https://mock-verifier.com"
+        let responseUri = "https://mock-verifier.com/response-uri"
+        _ = try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(),responseUri : responseUri)
+
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: "sending is success in AuthorizationResponseTests")
         let mockVPTokenSigningResults = [FormatType.ldp_vc : LdpVPTokenSigningResult(
             jws: "testJWS",
@@ -147,17 +148,17 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             publicKey: "testPublicKey",
             domain: "testDomain"
         )]
-        _ =  try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(), responseUri : "/response-uri")
+        _ =  try authorizationResponseHandler.constructUnsignedVPToken(credentialsMap: verifiableCredentials, authorizationRequest: getMockAuthorizationRequest(), responseUri : responseUri)
         
         let result = try await authorizationResponseHandler.shareVP(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode, vpTokenSigningResults: mockVPTokenSigningResults, responseUri: responseUri)
         
         XCTAssertEqual("sending is success in AuthorizationResponseTests", result)
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
-        let decodedPresentationSubmission = decodeQueryValue((recordedRequest.requestBody?["presentation_submission"])!)
-        let decodedVPToken = decodeQueryValue((recordedRequest.requestBody?["vp_token"])!)
+        let decodedVPToken = decodeQueryValue(jsonString(recordedRequest.requestBody?["vp_token"]! ?? "") ?? "")
         XCTAssertTrue(recordedRequest.requestBody?.keys.count == 3)
+        XCTAssertTrue(recordedRequest.requestBody?["presentation_submission"] != nil)
         assertJsonString(expected: expectedVPToken, actual: decodedVPToken, strict: false)
-        XCTAssertEqual("state", recordedRequest.requestBody?["state"])
+        XCTAssertEqual("state", recordedRequest.requestBody?["state"] as! String)
     }
     
     /// more than one VP format in response_type vp_token -> formats: ldp_vc, mso_mdoc
@@ -189,7 +190,8 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertTrue(recordedRequest.requestBody?.keys.count == 1)
         XCTAssertTrue(recordedRequest.requestBody?["response"] != nil)
-        XCTAssertTrue(((recordedRequest.requestBody?["response"]?.starts(with: "ey")) != nil))
+        //TODO: Cross check
+        XCTAssertTrue((((recordedRequest.requestBody?["response"] as! String).starts(with: "ey")) != nil))
     }
     
     func testShareVPThrowErrorWhenResponseTypeIsNotSupportedByLibrary() async  {
@@ -287,7 +289,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         _ = try await authorizationResponseHandler.shareVP(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode, vpTokenSigningResults: mockVPTokenSigningResults, responseUri: responseUri)
         
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
-        let decodedPresentationSubmission = decodeQueryValue((recordedRequest.requestBody?["presentation_submission"])!)
+        let decodedPresentationSubmission = decodeQueryValue(jsonString(recordedRequest.requestBody?["presentation_submission"]! ?? "") ?? "")
         assertJsonString(expected: expectedPresentationSubmission, actual: decodedPresentationSubmission, strict: false)
     }
 }

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedLdpVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedLdpVPTokenBuilderTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import OpenID4VP
+
+final class UnsignedLdpVPTokenBuilderTests: XCTestCase {
+    func testCreationOfUnsignedLdpVPToken() throws {
+        let unsignedLdpVPToken : UnsignedLdpVPToken = try UnsignedLdpVPTokenBuilder(verifiableCredential: [ldpVC()], id: "ebc6f1c2", holder: "did:example:wallet").build() as! UnsignedLdpVPToken
+        
+        XCTAssertEqual(unsignedLdpVPToken.context, ["https://www.w3.org/2018/credentials/v1"])
+        XCTAssertEqual(unsignedLdpVPToken.type, ["VerifiablePresentation"])
+        XCTAssertEqual(unsignedLdpVPToken.id, "ebc6f1c2")
+        XCTAssertEqual(unsignedLdpVPToken.holder, "did:example:wallet")
+        XCTAssertTrue(unsignedLdpVPToken.verifiableCredential.count == 1)
+    }
+    
+    func testCreationOfUnsignedLdpVPTokenContextHavingItPopulatedFromCredential() throws {
+        let unsignedLdpVPToken : UnsignedLdpVPToken = try UnsignedLdpVPTokenBuilder(verifiableCredential: [ldpVC(context: ["https://example.com/context1","https://example.com/context2"]), ldpVC(credentialType: "DegreeCredential", context: ["https://example.com/degreeContext1","https://example.com/context2"])], id: "ebc6f1c2", holder: "did:example:wallet").build() as! UnsignedLdpVPToken
+        
+        assertArraysEqual(expected: unsignedLdpVPToken.context, actual: ["https://example.com/degreeContext1", "https://example.com/context1"])
+    }
+}

--- a/Tests/OpenID4VPTests/Common/AnyCodableTests.swift
+++ b/Tests/OpenID4VPTests/Common/AnyCodableTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import OpenID4VP
+
+final class AnyCodableTests: XCTestCase {
+    
+    func testIntEncoding() throws {
+        let intValue = AnyCodable(42)
+        let encoded = try JSONEncoder().encode(intValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        
+        XCTAssertEqual(decoded.value as? Int, 42)
+    }
+    
+    func testDoubleEncoding() throws {
+        let doubleValue = AnyCodable(3.14)
+        let encoded = try JSONEncoder().encode(doubleValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        
+        XCTAssertEqual(decoded.value as? Double, 3.14)
+    }
+    
+    func testStringEncoding() throws {
+        let stringValue = AnyCodable("test string")
+        let encoded = try JSONEncoder().encode(stringValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        
+        XCTAssertEqual(decoded.value as? String, "test string")
+    }
+    
+    func testBoolEncoding() throws {
+        let boolValue = AnyCodable(true)
+        let encoded = try JSONEncoder().encode(boolValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        
+        XCTAssertEqual(decoded.value as? Bool, true)
+    }
+
+    
+    func testDictionaryEncoding() throws {
+        let dict: [String: Any] = ["key1": "value1", "key2": 42, "key3": true]
+        let dictValue = AnyCodable(dict)
+        let encoded = try JSONEncoder().encode(dictValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        let decodedDict = decoded.value as? [String: Any]
+        
+        XCTAssertNotNil(decodedDict)
+        XCTAssertEqual(decodedDict?["key1"] as? String, "value1")
+        XCTAssertEqual(decodedDict?["key2"] as? Int, 42)
+        XCTAssertEqual(decodedDict?["key3"] as? Bool, true)
+    }
+    
+    func testArrayEncoding() throws {
+        let array: [Any] = ["string", 42, true, 3.14]
+        let arrayValue = AnyCodable(array)
+        let encoded = try JSONEncoder().encode(arrayValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        let decodedArray = decoded.value as? [Any]
+        
+        XCTAssertNotNil(decodedArray)
+        XCTAssertEqual(decodedArray?.count, 4)
+        XCTAssertEqual(decodedArray?[0] as? String, "string")
+        XCTAssertEqual(decodedArray?[1] as? Int, 42)
+        XCTAssertEqual(decodedArray?[2] as? Bool, true)
+        XCTAssertEqual(decodedArray?[3] as? Double, 3.14)
+    }
+    
+    func testNestedStructures() throws {
+        let nested: [String: Any] = [
+            "string": "value",
+            "number": 42,
+            "array": [1, 2, 3],
+            "dict": ["nested": "value"]
+        ]
+        
+        let nestedValue = AnyCodable(nested)
+        let encoded = try JSONEncoder().encode(nestedValue)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+        let decodedNested = decoded.value as? [String: Any]
+        
+        XCTAssertNotNil(decodedNested)
+        XCTAssertEqual(decodedNested?["string"] as? String, "value")
+        XCTAssertEqual(decodedNested?["number"] as? Int, 42)
+        
+        let nestedArray = decodedNested?["array"] as? [Any]
+        XCTAssertEqual(nestedArray?.count, 3)
+        
+        let nestedDict = decodedNested?["dict"] as? [String: Any]
+        XCTAssertEqual(nestedDict?["nested"] as? String, "value")
+    }
+    
+    func testInvalidEncoding() {
+        let invalidValue = AnyCodable(Date())
+        
+        XCTAssertThrowsError(try JSONEncoder().encode(invalidValue)) { error in
+            XCTAssertEqual("Json Encoding failed for  due to this error: Error occured while encoding response.", error.localizedDescription)
+        }
+    }
+    
+    func testDecodeNil() throws {
+        // Create JSON with null value
+        let jsonData = """
+        null
+        """.data(using: .utf8)!
+        
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: jsonData)
+        XCTAssertTrue(decoded.value is Optional<Any>)
+    }
+}

--- a/Tests/OpenID4VPTests/Common/JSONEncoderTests.swift
+++ b/Tests/OpenID4VPTests/Common/JSONEncoderTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import OpenID4VP
+
+final class JSONEncoderTests: XCTestCase {
+    // Test struct to verify encoding behavior
+    private struct TestPerson: Encodable {
+        let name: String
+        let age: Int
+        let url: String
+        let nestedObject: NestedObject
+        let arrayOfStrings: [String]
+        
+        struct NestedObject: Encodable {
+            let id: Int
+            let value: String
+        }
+    }
+    
+    func testEncodableTojsonData() throws {
+        // Create test object with various data types including a URL with slashes
+        let testObject = TestPerson(
+            name: "John Doe",
+            age: 30,
+            url: "https://example.com/path/to/resource",
+            nestedObject: TestPerson.NestedObject(id: 1, value: "test"),
+            arrayOfStrings: ["one", "two", "three"]
+        )
+        
+        // Convert to dictionary using the extension
+        let result = try testObject.jsonData()
+        
+        // Verify the result is a dictionary
+        guard let dictionary = result as? [String: Any] else {
+            XCTFail("Result should be a dictionary")
+            return
+        }
+        
+        // Verify the expected values
+        XCTAssertEqual(dictionary["name"] as? String, "John Doe")
+        XCTAssertEqual(dictionary["age"] as? Int, 30)
+        XCTAssertEqual(dictionary["url"] as? String, "https://example.com/path/to/resource")
+        
+        // Check nested object
+        if let nestedDict = dictionary["nestedObject"] as? [String: Any] {
+            XCTAssertEqual(nestedDict["id"] as? Int, 1)
+            XCTAssertEqual(nestedDict["value"] as? String, "test")
+        } else {
+            XCTFail("Nested object not found or not a dictionary")
+        }
+        
+        // Check array
+        if let array = dictionary["arrayOfStrings"] as? [String] {
+            XCTAssertEqual(array, ["one", "two", "three"])
+        } else {
+            XCTFail("Array not found or not an array of strings")
+        }
+    }
+    
+    func testEncodableWithSpecialChars() throws {
+        struct SpecialCharsTest: Encodable {
+            let path: String
+            let query: String
+        }
+        
+        let test = SpecialCharsTest(
+            path: "/path/with/slashes",
+            query: "param=value&other=123"
+        )
+        
+        let result = try test.jsonData()
+        
+        guard let dict = result as? [String: String] else {
+            XCTFail("Result should be a dictionary of strings")
+            return
+        }
+        
+        // Verify slashes are not escaped
+        XCTAssertEqual(dict["path"], "/path/with/slashes")
+        XCTAssertEqual(dict["query"], "param=value&other=123")
+    }
+    
+    func testJSONEncoderOutputFormatting() {
+        XCTAssertTrue(JSON.encoder.outputFormatting.contains(.withoutEscapingSlashes))
+    }
+    
+    func testComplexNestedStructure() throws {
+        struct Complex: Encodable {
+            let metadata: Metadata
+            let data: [DataItem]
+            
+            struct Metadata: Encodable {
+                let version: String
+                let timestamp: Date
+            }
+            
+            struct DataItem: Encodable {
+                let id: String
+                let values: [String: Any]
+                
+                enum CodingKeys: String, CodingKey {
+                    case id, values
+                }
+                
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    try container.encode(id, forKey: .id)
+                    
+                    // Manual encoding for the dictionary
+                    let valuesData = try JSONSerialization.data(withJSONObject: values)
+                    let valuesString = String(data: valuesData, encoding: .utf8)
+                    try container.encode(valuesString, forKey: .values)
+                }
+            }
+        }
+        
+        let date = Date()
+        let complex = Complex(
+            metadata: Complex.Metadata(version: "1.0", timestamp: date),
+            data: [
+                Complex.DataItem(id: "item1", values: ["key1": "value1", "key2": 42])
+            ]
+        )
+        
+        XCTAssertNoThrow(try complex.jsonData())
+    }
+}

--- a/Tests/OpenID4VPTests/Common/UtilsTest.swift
+++ b/Tests/OpenID4VPTests/Common/UtilsTest.swift
@@ -147,7 +147,6 @@ class UtilsTest : XCTestCase {
         )
 
         let encodedJson = try encode(mockDataClass, fieldName: "mockDataClass", className: className)
-        print("data \(encodedJson)")
         let expectedJson = "{\"key\":\"id_credential\",\"number\":1,\"key_with_more_than_one_word\":\"ldp_vp\"}"
         
         assertJsonString(expected: expectedJson, actual: encodedJson)

--- a/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
+++ b/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class MockNetworkManager: NetworkManaging {
     private var mockResponses: [URL: (response: (responseBody: String, httpUrlResponse: HTTPURLResponse)?, error: Error?)] = [:]
-    var recordedRequests: [String: (requestMethod: HttpMethod,requestBody : [String: String]?, requestHeaders : [String: String]?)] = [:]
+    var recordedRequests: [String: (requestMethod: HttpMethod,requestBody : [String: Any]?, requestHeaders : [String: String]?)] = [:]
     
     func setMockResponse(for urlString: String, response: (responseBody: String, httpUrlResponse: HTTPURLResponse?)? = nil, responseBody: String? = nil, error: Error? = nil) {
         guard let url = URL(string: urlString) else {
@@ -24,11 +24,13 @@ class MockNetworkManager: NetworkManaging {
         mockResponses[url] = (finalResponse, error)
     }
     
+    //TODO: rename function to clear or clearResponses
     func clearMockResponses(){
         mockResponses = [:]
+        recordedRequests = [:]
     }
     
-    public func sendHTTPRequest(url: String, method: HttpMethod, bodyParams: [String:String]? = nil, headers: [String : String]? = nil) async throws -> (responseBody: String, httpUrlResponse: HTTPURLResponse) {
+    public func sendHTTPRequest(url: String, method: HttpMethod, bodyParams: [String:Any]? = nil, headers: [String : String]? = nil) async throws -> (responseBody: String, httpUrlResponse: HTTPURLResponse) {
         
         recordedRequests[url] = (requestMethod: method,requestBody: bodyParams, requestHeaders: headers)
         

--- a/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
+++ b/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
@@ -24,8 +24,7 @@ class MockNetworkManager: NetworkManaging {
         mockResponses[url] = (finalResponse, error)
     }
     
-    //TODO: rename function to clear or clearResponses
-    func clearMockResponses(){
+    func clearResponses(){
         mockResponses = [:]
         recordedRequests = [:]
     }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -285,7 +285,7 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
     
     func testSendAuthorizationResponseForDirectPostJwtResponseMode()  async throws {
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: "Response has been shared successfully here.")
-        let authorizationResponse: AuthorizationResponse = AuthorizationResponse(vpToken: mockVPTokens, presentation_submission: mockPresentationSubmission, state: "state")
+        let authorizationResponse: AuthorizationResponse = AuthorizationResponse(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
         
         do {
             let result = try await directPostJwtResponseModeHandler.sendAuthorizationResponse(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostJwtResponseMode, authorizationResponse: authorizationResponse, url: mockAuthorizationRequestObjectWithDirectPostJwtResponseMode.responseUri!, networkManager: mockNetworkManager,

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
     private let directPostJwtResponseModeHandler = DirectPostJwtResponseModeHandler()
-    let mockVPTokens = VPTokenType.vpTokenElement(LdpVPToken(context: ["context"], type: ["typ1"], verifiableCredential: ["VC1"], id: "identifier", holder: "holder", proof: Proof(type: "Ed25519Signature2018", created: "2021-03-19T15:30:15Z", challenge: "n-0S6_WzA2Mj", domain: "https://client.example.org/cb", jws: "eyJhbG...IAoDA", proofPurpose: .vpProofPurpose, verificationMethod: "did:example:holder#key-1")))
+    let mockVPTokens = VPTokenType.vpTokenElement(LdpVPToken(context: ["context"], type: ["typ1"], verifiableCredential: [ldpVC().mapValues { AnyCodable($0) }], id: "identifier", holder: "holder", proof: Proof(type: "Ed25519Signature2018", created: "2021-03-19T15:30:15Z", challenge: "n-0S6_WzA2Mj", domain: "https://client.example.org/cb", jws: "eyJhbG...IAoDA", proofPurpose: .vpProofPurpose, verificationMethod: "did:example:holder#key-1")))
     
     let mockPresentationSubmission = PresentationSubmission(definitionId: "client-identifier", descriptorMap: [DescriptorMap(id: "input_1", format: .ldp_vp, path: "$", pathNested: PathNested(id: "input_1", format: .ldp_vc, path: "$.verifiableCredential[0]"))])
     private let mockNetworkManager = MockNetworkManager()

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -24,8 +24,8 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
     
     func testSendAuthorizationResponseForDirectPostResponseMode()  async throws {
         let directPostAuthorizationResponseModeHandler = DirectPostResponseModeHandler()
-        let authorizationResponse: AuthorizationResponse = AuthorizationResponse(vpToken: mockVPTokens, presentation_submission: mockPresentationSubmission, state: "state")
-        mockNetworkManager.clearMockResponses()
+        let authorizationResponse: AuthorizationResponse = AuthorizationResponse(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
+        mockNetworkManager.clearResponses()
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: "Response has been shared successfully here.")
         
         do {

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -25,6 +25,7 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
     func testSendAuthorizationResponseForDirectPostResponseMode()  async throws {
         let directPostAuthorizationResponseModeHandler = DirectPostResponseModeHandler()
         let authorizationResponse: AuthorizationResponse = AuthorizationResponse(vpToken: mockVPTokens, presentation_submission: mockPresentationSubmission, state: "state")
+        mockNetworkManager.clearMockResponses()
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: "Response has been shared successfully here.")
         
         do {

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import OpenID4VP
 
 final class DirectPostResponseModeHandlerTests: XCTestCase {
-    let mockVPTokens = VPTokenType.vpTokenElement(LdpVPToken(context: ["context"], type: ["typ1"], verifiableCredential: ["VC1"], id: "identifier", holder: "holder", proof: Proof(type: "Ed25519Signature2018", created: "2021-03-19T15:30:15Z", challenge: "n-0S6_WzA2Mj", domain: "https://client.example.org/cb", jws: "eyJhbG...IAoDA", proofPurpose: .vpProofPurpose, verificationMethod: "did:example:holder#key-1")))
+    let mockVPTokens = VPTokenType.vpTokenElement(LdpVPToken(context: ["context"], type: ["typ1"], verifiableCredential: [ldpVC().mapValues { AnyCodable($0) }], id: "identifier", holder: "holder", proof: Proof(type: "Ed25519Signature2018", created: "2021-03-19T15:30:15Z", challenge: "n-0S6_WzA2Mj", domain: "https://client.example.org/cb", jws: "eyJhbG...IAoDA", proofPurpose: .vpProofPurpose, verificationMethod: "did:example:holder#key-1")))
     
     let mockPresentationSubmission = PresentationSubmission(definitionId: "client-identifier", descriptorMap: [DescriptorMap(id: "input_1", format: .ldp_vp, path: "$", pathNested: PathNested(id: "input_1", format: .ldp_vc, path: "$.verifiableCredential[0]"))])
     

--- a/Tests/OpenID4VPTests/TestData/TestData.swift
+++ b/Tests/OpenID4VPTests/TestData/TestData.swift
@@ -18,7 +18,7 @@ private let testVerifierList:  [[String: Any]]  = [
 
 let preRegisteredVerifiers = createVerifiers(from: testVerifierList)
 
-let verifiableCredentialsList : [String : [FormatType : Array<Any>]] = ["input_descriptor1": [FormatType.ldp_vc : ["VC1"]]]
+let verifiableCredentialsList : [String : [FormatType : Array<Any>]] = ["input_descriptor1": [FormatType.ldp_vc : [ldpVC()]]]
 
 let didDocumentUrl = "https://inji-ovp/inji-mock-services/openid4vp-service/docs/did.json"
 let httpUrlResponseForJWS: HTTPURLResponse = HTTPURLResponse(url: URL(string: didDocumentUrl)!, statusCode: 200, httpVersion: "", headerFields: ["Content-Type": "application/oauth-authz-req+jwt"])!

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -132,6 +132,22 @@ func decodeQueryValue(_ value: String) -> String {
     return value.removingPercentEncoding ?? value
 }
 
+func jsonString(_ any: Any, prettyPrinted: Bool = false) -> String? {
+    guard JSONSerialization.isValidJSONObject(any) else {
+        print("Not a valid JSON object")
+        return nil
+    }
+    
+    do {
+        let options: JSONSerialization.WritingOptions = prettyPrinted ? [.prettyPrinted] : []
+        let data = try JSONSerialization.data(withJSONObject: any, options: options)
+        return String(data: data, encoding: .utf8)
+    } catch {
+        print("Error serializing to JSON: \(error)")
+        return nil
+    }
+}
+
 func createInstance<T: Decodable>(_ json: [String: Any], as type: T.Type) -> T {
     let jsonData = try? JSONSerialization.data(withJSONObject: json, options: [])
     let decoder = JSONDecoder()

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -195,9 +195,13 @@ func createWalletMetadata(
     )
 }
 
-func ldpVC(credentialType : String = "IDCardCredential", context: [String] = [
+func ldpVC(credentialType : String = "IDCardCredential", context: [Any] = [
     "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1",
+    [
+        "sec": "https://w3id.org/security#"
+    ]
+    
 ]) -> [String: Any] {
     let data : [String: Any] = [
         "@context": context,

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -178,3 +178,34 @@ func createWalletMetadata(
         authorizationEncryptionEncValuesSupported: authorizationEncryptionEncValuesSupported
     )
 }
+
+func ldpVC(credentialType : String = "IDCardCredential", context: [String] = [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+]) -> [String: Any] {
+    let data : [String: Any] = [
+        "@context": context,
+        "id": "https://example.com/credentials/1872",
+        "type": [
+            "VerifiableCredential",
+            credentialType
+        ],
+        "issuer": [
+            "id": "did:example:issuer"
+        ],
+        "issuanceDate": "2010-01-01T19:23:24Z",
+        "credentialSubject": [
+            "given_name": "MockUser",
+            "family_name": "Mockister",
+            "birthdate": "1949-01-22"
+        ],
+        "proof": [
+            "type": "Ed25519Signature2018",
+            "created": "2021-03-19T15:30:15Z",
+            "jws": "eyJhb...JQdBw",
+            "proofPurpose": "assertionMethod",
+            "verificationMethod": "did:example:issuer#keys-1"
+        ]
+    ]
+    return data
+}

--- a/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
+++ b/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
@@ -133,3 +133,13 @@ func XCTAssertNoThrowAndVerify<T>(_ expression: @autoclosure () throws -> T,
         XCTFail("Expression threw an error: \(error)", file: file, line: line)
     }
 }
+
+// Write a custom assertion for comparing two arrays
+func assertArraysEqual<T: Equatable>(expected: [T], actual: [T], file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(expected.count, actual.count, "Array sizes are different", file: file, line: line)
+    
+    expected.forEach { expectedElement in
+        XCTAssertTrue(actual.contains(expectedElement), "Expected element \(expectedElement) not found in actual array", file: file, line: line)
+    }
+}
+


### PR DESCRIPTION
Changes include
1. In case of ldp_vc's, context of the VP is calculated by taking the unique entries of first element from all VCs context array
2. Authorization response is sent in JSON format instead of JSON string
3. Readme update

Others
- Refactoring to group similar functions to file