### PR TITLE
[INJIMOB-3391] fix: create walletNonce per transaction

### DIFF
--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -6,13 +6,12 @@ public class AuthorizationResponseHandler {
     private var unsignedVPTokens: [FormatType: [String:Any]] = [:]
     private var path: [FormatType: (index: Int, nestedIndex: Int)] = [:]
     private var credentialsMap: [String: [FormatType: Array<Any>]]?
-    private let walletNonce: String
+    private var walletNonce: String = ""
 
     public static let className = String(describing: AuthorizationResponseHandler.self)
 
     public init(networkManager: NetworkManaging) {
         self.networkManager = networkManager
-        walletNonce = createNonce()
     }
 
     func constructUnsignedVPToken(
@@ -31,8 +30,10 @@ public class AuthorizationResponseHandler {
         }
 
         self.credentialsMap = credentialsMap
+        // Create wallet nonce for every transaction
+        self.walletNonce = createNonce()
 
-           unsignedVPTokens = try createUnsignedVPTokens(
+        unsignedVPTokens = try createUnsignedVPTokens(
             credentialsMap: credentialsMap,
             authorizationRequest: authorizationRequest,
             responseUri: responseUri,

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -5,6 +5,40 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
     let mockNetworkManager = MockNetworkManager()
     let state = "state"
     let responseUri = "https://mock-verifier.com"
+    
+    func testWalletNonceIsDifferentForEveryConstructUnsignedVPTokenCall() throws {
+        let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager)
+        let verifiableCredentials: [String: [FormatType: [AnyCodable]]] = [
+            "input_descriptor1": [.ldp_vc: [AnyCodable(ldpVC())]]
+        ]
+        let authorizationRequest = getMockAuthorizationRequest()
+        
+        // First call
+        _ = try handler.constructUnsignedVPToken(
+            credentialsMap: verifiableCredentials,
+            authorizationRequest: authorizationRequest,
+            responseUri: responseUri,
+            holderId: "",
+            signatureSuite: "JsonWebSignature2020"
+        )
+        // Get the nonce from the first call using reflection
+        let firstMirror = Mirror(reflecting: handler)
+        let firstNonce = firstMirror.children.first(where: { $0.label == "walletNonce" })?.value as? String
+        
+        // Second call
+        _ = try handler.constructUnsignedVPToken(
+            credentialsMap: verifiableCredentials,
+            authorizationRequest: authorizationRequest,
+            responseUri: responseUri,
+            holderId: "",
+            signatureSuite: "JsonWebSignature2020"
+        )
+        // Get the nonce from the second call using reflection
+        let secondMirror = Mirror(reflecting: handler)
+        let secondNonce = secondMirror.children.first(where: { $0.label == "walletNonce" })?.value as? String
+        
+        XCTAssertNotEqual(firstNonce, secondNonce, "Wallet nonce should be different for every constructUnsignedVPToken call")
+    }
 
     func testShareVPHasTheAuthorizationResponseAsExpected() async throws {
         let verifiableCredentials: [String: [FormatType: [AnyCodable]]] = [


### PR DESCRIPTION

walletNonce is created during construction of unSignedVPToken now so that its unique per transaction and not unique per OpenId4VP class instance. 

Why nonce needs to be unique per transaction?
- A nonce must be unique per transaction to prevent replay attacks, ensuring a request cannot be reused.