### PR TITLE
[INJIMOB-3571] | [INJIMOB-3572] add: support for jwksUri and allowUnsignedRequest

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
@@ -4,7 +4,7 @@ import Foundation
 protocol AbstractMethodsForClientIdSchemeBasedAuthorizationRequestHandler {
     func process(walletMetadata: WalletMetadata) throws -> WalletMetadata
     func isRequestUriSupported() -> Bool
-    func isRequestObjectSupported() -> Bool
+    func isRequestObjectSupported() throws -> Bool
     func extractPublicKey(keyId: String?, algorithm: String) async throws -> PublicKeyType
     func clientIdScheme() -> String
 }
@@ -91,7 +91,7 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerBaseClass  {
             }
             try await validateRequestUriResponse(response.responseBody, httpMethod: httpMethod)
         } else {
-            guard (delegate.isRequestObjectSupported()) else {
+            guard (try delegate.isRequestObjectSupported()) else {
                 throw InvalidData(
                     message: "request object is not supported for given client_id_scheme - \(delegate.clientIdScheme())",
                     className: className

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredSchemeAuthorizationRequestHandler.swift
@@ -46,63 +46,46 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdSchemeBasedAuthor
     }
     
     
-    func isRequestObjectSupported() -> Bool {
-        return true
+    func isRequestObjectSupported() throws -> Bool {
+        if shouldValidateClient {
+            let clientId = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId.rawValue]) ?? ""
+            let preRegisteredVerifier = try verifier(clientId: clientId)
+            return preRegisteredVerifier.allowUnsignedRequest
+        }
+        return false
     }
     
     func extractPublicKey(keyId: String?, algorithm: String) async throws -> PublicKeyType {
         let clientId = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId.rawValue] as? String
         
-        if ((authorizationRequestParameters[AuthorizationRequestFieldConstants.clientMetadata.rawValue]) != nil)  {
-            throw InvalidData(
-                message: "client_metadata available in Authorization Request, cannot be used to verify the signed Authorization Request",
+        let preRegisteredClient = try verifier(clientId: clientId ?? "")
+        if let jwksUri = preRegisteredClient.jwksUri {
+            let jwkSet : JWKSet = try await resolveJwksFromUri(jwksUri, networkManager: self.networkManager, className: className)
+            
+            let publicKeyJwk =  try filterAndExtractKey(jwks: jwkSet, keyId: keyId, algorithm: algorithm)
+            return try jwkToPublicKey(publicKeyJwk, className: className)
+        } else {
+            throw PublicKeyResolutionFailed(
+                message: "Public key extraction failed - Public key information not available in pre-registered data to verify the signed Authorization Request",
                 className: className,
-                code: OpenID4VPErrorCodes.invalidRequest
+                code: OpenID4VPErrorCodes.invalidRequestObject
             )
         }
-        
-        if let preRegisteredClient = trustedVerifiers.filter({ $0.clientId == clientId }).first {
-            if let publicKeys = preRegisteredClient.clientMetadata?.jwks {
-                let publicKeyJwk =  try filterAndExtractKey(jwks: publicKeys, keyId: keyId, algorithm: algorithm)
-                return try jwkToPublicKey(publicKeyJwk, className: className)
-            } else {
-                throw InvalidData(
-                    message: "Public key extraction failed - Either client_metadata not available or jwks not available in pre-registered client_metadata to verify the signed Authorization Request",
-                    className: className,
-                    code: OpenID4VPErrorCodes.invalidRequestObject
-                )
-            }
-            
-        }
-        throw PublicKeyResolutionFailed(message: "Public key extraction failed for keyId = \(keyId ?? "null"), algorithm: \(algorithm)",
-                                        className: className,
-                                        code: OpenID4VPErrorCodes.invalidRequestObject)
     }
     
     override func validateAndParseRequestFields() async throws {
         if shouldValidateClient {
             let clientId = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId.rawValue] as! String
-            if let preRegisteredClient = trustedVerifiers.filter({ $0.clientId == clientId }).first {
-                let responseUri = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri.rawValue]) ?? "null"
-                guard preRegisteredClient.responseUris.contains(responseUri) else {
-                    throw InvalidVerifier(
-                        message: "response_uri trust cannot be established",
-                        className: AuthorizationRequest.className
-                    )
-                }
-                if(preRegisteredClient.clientMetadata != nil) {
-                    if (authorizationRequestParameters.keys.contains(AuthorizationRequestFieldConstants.clientMetadata.rawValue)){
-                        throw InvalidVerifier(
-                            message: "client_metadata provided despite pre-registered metadata already existing for the Client Identifier.",
-                            className: AuthorizationRequest.className
-                        )
-                    }
-                    
-                    
-                    // Update client_metadata in authorizationRequestParameters from the registered client for further use
-                    authorizationRequestParameters[AuthorizationRequestFieldConstants.clientMetadata.rawValue] = preRegisteredClient.clientMetadata
-                }
+            let preRegisteredClient = try verifier(clientId: clientId)
+            
+            let responseUri = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri.rawValue]) ?? "null"
+            guard preRegisteredClient.responseUris.contains(responseUri) else {
+                throw InvalidVerifier(
+                    message: "response_uri trust cannot be established",
+                    className: AuthorizationRequest.className
+                )
             }
+            
         }
         try await super.validateAndParseRequestFields()
     }
@@ -130,6 +113,14 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdSchemeBasedAuthor
             throw PublicKeyResolutionFailed(message: "Public key extraction failed - Multiple ambiguous keys found for \(algorithm) with signature usage",
                                             className: className,
                                             code: OpenID4VPErrorCodes.invalidRequestObject)
+        }
+    }
+    
+    private func verifier(clientId: String) throws -> Verifier {
+        if let found = trustedVerifiers.first(where: { $0.clientId == clientId }) {
+            return found
+        } else {
+            throw InvalidVerifier(message: "Verifier is not trusted by the wallet", className: className)
         }
     }
 }

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JSONWebKey
 import CryptoKit
 import SwiftCBOR
 
@@ -118,4 +119,24 @@ func createNestedPath(id: String, nestedPath: String?, format: FormatType) -> Pa
 
 func createDescriptorMapPath(_ index: Int) -> String {
     return "$[\(index)]"
+}
+
+func resolveJwksFromUri(_ uri: String, networkManager: NetworkManaging, className: String) async throws -> JWKSet {
+    do {
+        let response = try await networkManager.sendHTTPRequest(url: uri, method: .get, bodyParams: nil, headers: nil)
+        let data = try response.responseBody.data(using: .utf8) ?? {
+           throw InvalidData(
+                message: "unable to convert the jwks response to data",
+                className: className,
+                code: OpenID4VPErrorCodes.invalidRequestObject
+            )
+        }()
+        return try data.toInstance(as: JWKSet.self)
+    } catch {
+        throw InvalidData(
+            message: "Public key extraction failed - Unable to fetch/parse jwks from \(uri) due to \(error.localizedDescription)",
+            className: className,
+            code: OpenID4VPErrorCodes.invalidRequestObject
+                )
+    }
 }

--- a/Sources/OpenID4VP/dto/Verifier.swift
+++ b/Sources/OpenID4VP/dto/Verifier.swift
@@ -3,12 +3,13 @@ import Foundation
 public struct Verifier {
     public let clientId: String
     public let responseUris: [String]
-    // For a pre-registered Verifier, the ClientMetadata is known before the Authorization Request is created itself.
-    public let clientMetadata: ClientMetadata?
+    public let jwksUri: String?
+    public let allowUnsignedRequest: Bool
 
-    public init(clientId: String, responseUris: [String], clientMetadata: ClientMetadata? = nil) {
+    public init(clientId: String, responseUris: [String], jwksUri: String? = nil, allowUnsignedRequest: Bool = false) {
         self.clientId = clientId
         self.responseUris = responseUris
-        self.clientMetadata = clientMetadata
+        self.jwksUri = jwksUri
+        self.allowUnsignedRequest = allowUnsignedRequest
     }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdSchemeAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdSchemeAuthorizationRequestTests.swift
@@ -5,6 +5,7 @@ import JSONWebKey
 
 class PreRegisteredClientIdSchemeTests : XCTestCase {
     let mockNetworkManager: MockNetworkManager! = MockNetworkManager()
+    let mockNetworkManagerReal: NetworkManager! = NetworkManager()
     let mockSetResponseUri: (String) -> Void = { value in
     }
     
@@ -60,11 +61,33 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
     }
 
 
-    func testReturnTrueForAuthorizationRequestByValueSupport() {
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValueDraft23 , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: preRegisteredVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+    func testIsRequestObjectSupported_shouldValidateClientFalse_returnsFalse() {
+        let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId.rawValue: "mock-client"]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: preRegisteredVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: false, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        XCTAssertFalse(try preRegistered.isRequestObjectSupported(), "Should return false when shouldValidateClient is false")
+    }
+
+    func testIsRequestObjectSupported_shouldValidateClientTrue_clientIdNotAvailable_throwsError() {
+        let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId.rawValue: "untrusted-client"]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: preRegisteredVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
-        XCTAssertTrue(preRegistered.isRequestObjectSupported(), "Pre-registered client id scheme should support authorization request by value")
+        XCTAssertThrowsError(try preRegistered.isRequestObjectSupported()) { error in
+            assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
+        }
+    }
+
+    func testIsRequestObjectSupported_shouldValidateClientTrue_clientIdAvailable_allowUnsignedFalse_returnsFalse() {
+        let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], allowUnsignedRequest: false)]
+        let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId.rawValue: "mock-client"]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: trustedVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        XCTAssertFalse(try preRegistered.isRequestObjectSupported(), "Should return false when allowUnsignedRequest is false")
+    }
+
+    func testIsRequestObjectSupported_shouldValidateClientTrue_clientIdAvailable_allowUnsignedTrue_returnsTrue() {
+        let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], allowUnsignedRequest: true)]
+        let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId.rawValue: "mock-client"]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: trustedVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        XCTAssertTrue(try preRegistered.isRequestObjectSupported(), "Should return true when allowUnsignedRequest is true")
     }
 
     
@@ -96,53 +119,6 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
         }
     }
     
-    func testThrowExceptionWhenClientIdIsAvailableInTrustedVerifierListWithClientMetadataButClientMetadataIsAlsoAvailableInAuthorizationRequest() async throws {
-        let clientMetadataString = """
-                {
-                    "client_name": "Valid Client",
-                    "logo_uri": "https://example.com/logo.png",
-                    "authorization_encrypted_response_alg": "RSA-OAEP",
-                    "authorization_encrypted_response_enc": "A256GCM",
-                    "vp_formats": { "format1": { "type1": ["value1"] } },
-                    "jwks": { "keys": [{ "kty": "RSA", "crv": "P-256", "use": "sig", "alg": "RS256", "kid": "1", "x": "ur76rg" }] }
-                }
-            """.data(using: .utf8)!
-        let clientMetadata = try ClientMetadata.deserializeAndValidate(clientMetadata: clientMetadataString)
-        let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], clientMetadata: clientMetadata)]
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValueDraft23 + [AuthorizationRequestFieldConstants.clientMetadata.rawValue], requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: trustedVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        
-        await XCTAssertAsyncThrowsError(try await preRegistered.validateAndParseRequestFields()) { error in
-            assertOpenID4VPException(
-                error,
-                expectedMessage: "client_metadata provided despite pre-registered metadata already existing for the Client Identifier.",
-                expectedCode: OpenID4VPErrorCodes.invalidClient
-            )
-        }
-    }
-    
-    func testAutorizationRequestUpdatedWithClientMetadataForPreRegisteredVerifierWhichHasClientMetadataStored() async throws {
-        let clientMetadataString = """
-                {
-                    "client_name": "Valid Client",
-                    "logo_uri": "https://example.com/logo.png",
-                    "authorization_encrypted_response_alg": "RSA-OAEP",
-                    "authorization_encrypted_response_enc": "A256GCM",
-                    "vp_formats": { "format1": { "type1": ["value1"] } },
-                    "jwks": { "keys": [{ "kty": "RSA", "crv": "P-256", "use": "sig", "alg": "RS256", "kid": "1", "x": "ur76rg" }] }
-                }
-            """
-        let clientMetadata = try ClientMetadata.deserializeAndValidate(clientMetadata: clientMetadataString)
-        let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], clientMetadata: clientMetadata)]
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValueDraft23.filter {$0 != "client_metadata"}, requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: trustedVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: nil, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        
-        try await preRegistered.validateAndParseRequestFields()
-        
-        let clientMetadataInAuthRequest = preRegistered.authorizationRequestParameters[AuthorizationRequestFieldConstants.clientMetadata.rawValue]
-        assertJsonString(expected: clientMetadataString, actual: convertToJsonString(clientMetadataInAuthRequest as! ClientMetadata))
-    }
-    
     /// Fetch authorization request by value - validate authorization request object and authorization request query paramaters
     
     func testFetchAuthorizationRequestOnValidPreRegisteredSchemeAuthRequestSentByValue() async{
@@ -153,6 +129,7 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
             "nonce": "VbRRB/LTxLiXmVNZuyMO8A==",
             "state": "+mRQe1d6pBoJqF6Ab28klg==",
             "response_uri": "https://mock-verifier.com",
+            "client_metadata": (clientMetadata),
             "presentation_definition": [
                 "input_descriptors": [[
                     "format": [
@@ -199,43 +176,27 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
         
         assertDictionariesEqual(expected: convertToDictionary(object: expectedWalletMetadata)!, actual: convertToDictionary(object: processedMetadata))
     }
-
-    func testExtractPublicKeyThrowErrorWhenClientMetadataAvailableInAuthorizationRequestParameters() async throws {
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValueDraft23 + ["client_metadata"], requestParams: authorizationRequestParamsWithValue) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: preRegisteredVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: walletMetadata, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
-        
-        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")){ error in
-            assertOpenID4VPException(error, expectedMessage: "client_metadata available in Authorization Request, cannot be used to verify the signed Authorization Request", expectedCode: OpenID4VPErrorCodes.invalidRequest)
-        }
-    }
     
     func testExtractPublicKeyThrowErrorWhenPreRegisteredClientNotAvailable() async throws {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValueDraft23, requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted-client"])) as [String : Any]
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: preRegisteredVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: walletMetadata, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")){ error in
-            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed for keyId = ed-key2, algorithm: ECDSA", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+            assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
         }
     }
     
     // clientMetadata available for trusted verifiers does not have jwks
-    func testExtractPublicKeyThrowErrorWhenJwksNotAvailable() async throws {
+    func testExtractPublicKeyThrowErrorWhenJwksUriNotAvailable() async throws {
         let trustedVerifiers = [
-            Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], clientMetadata: ClientMetadata(vpFormats: [
-                "ldp_vp": [
-                    "proof_type": [
-                        "Ed25519Signature2018",
-                        "Ed25519Signature2020"
-                    ]
-                ]
-            ]))
+            Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"])
         ]
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValueDraft23 , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)) as [String : Any]
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(trustedVerifiers: trustedVerifiers, authorizationRequestParameters: authorizationRequestParameters, walletMetadata: walletMetadata, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "EdDSA")){ error in
-            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Either client_metadata not available or jwks not available in pre-registered client_metadata to verify the signed Authorization Request", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Public key information not available in pre-registered data to verify the signed Authorization Request", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
         }
     }
     
@@ -248,153 +209,9 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
     
     
     func testExtractPublicKeySuccessForKeyId() async throws {
-        let trustedVerifiers = preRegisteredVerifiers
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
             paramList: authRequestWithPreRegisteredByValueDraft23,
             requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
-        ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
-            trustedVerifiers: trustedVerifiers,
-            authorizationRequestParameters: authorizationRequestParameters,
-            walletMetadata: walletMetadata,
-            shouldValidateClient: true,
-            setResponseUri: mockSetResponseUri,
-            walletNonce: "mock-nonce",
-            networkManager: mockNetworkManager!
-        )
-        
-        let publicKey = try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "Ed25519")
-        
-        assertPublicKey(expectedBase64Encoded: "5tvU4k/TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc=", actualKey: publicKey)
-    }
-    
-    func testExtractPublicKeySuccessForAlgorithmAndUsage() async throws {
-        let trustedVerifier = Verifier(clientId: "mock-client", responseUris: ["/response-uri"], clientMetadata: ClientMetadata(
-            vpFormats: ["format1": [ "type1": ["value1"] ]],
-            jwks: JWKSet(keys: [
-                try convertToInstance([
-                    "kty": "OKP",
-                    "crv": "Ed25519",
-                    "use": "sig",
-                    "alg": "EdDSA",
-                    "kid": "ed-key1",
-                    "x": "5tvU4k_TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc",
-                    "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
-                ], as: JWK.self),
-                try convertToInstance([
-                    "kty": "RSA",
-                    "crv": "P-256",
-                    "use": "sig",
-                    "alg": "RS256",
-                    "kid": "rsa-key1",
-                    "x": "ur76rg",
-                    "y": "x_FEzRu9m36HLN_tue659LNp"
-                ], as: JWK.self)
-            ])
-        ))
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
-            paramList: authRequestWithPreRegisteredByValueDraft23,
-            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
-        ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
-            trustedVerifiers: [trustedVerifier],
-            authorizationRequestParameters: authorizationRequestParameters,
-            walletMetadata: walletMetadata,
-            shouldValidateClient: true,
-            setResponseUri: mockSetResponseUri,
-            walletNonce: "mock-nonce",
-            networkManager: mockNetworkManager!
-        )
-        
-        
-        await XCTAssertNoThrowAndVerifyAsync(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "EdDSA")) { publicKey in
-            assertPublicKey(expectedBase64Encoded: "5tvU4k/TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc=", actualKey: publicKey)
-        }
-    }
-    
-    func testExtractPublicKeyThrowErrorWhenAlgorithmAndKeyUsageDoesNotMatchInAvailableJWKS() async throws {
-        let trustedVerifier = Verifier(clientId: "mock-client", responseUris: ["/response-uri"], clientMetadata: ClientMetadata(
-            vpFormats: ["format1": [ "type1": ["value1"] ]],
-            jwks: JWKSet(keys: [
-                try convertToInstance([
-                    "kty": "EC",
-                    "crv": "P-256",
-                    "use": "sig",
-                    "alg": "ES256",
-                    "kid": "ec-key1",
-                    "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
-                    "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
-                ], as: JWK.self)
-            ])
-        ))
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
-            paramList: authRequestWithPreRegisteredByValueDraft23,
-            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
-        ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
-            trustedVerifiers: [trustedVerifier],
-            authorizationRequestParameters: authorizationRequestParameters,
-            walletMetadata: walletMetadata,
-            shouldValidateClient: true,
-            setResponseUri: mockSetResponseUri,
-            walletNonce: "mock-nonce",
-            networkManager: mockNetworkManager!
-        )
-        
-        
-        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "Ed25519")) { error in
-            assertOpenID4VPException(error, expectedMessage: "No public key found for algorithm: Ed25519 with key use: signature", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
-        }
-    }
-    
-    func testExtractPublicKeyThrowErrorWhenMultipleEntriesAreFoundForAlgorithmAndUsage() async throws {
-        let trustedVerifier = Verifier(clientId: "mock-client", responseUris: ["/response-uri"], clientMetadata: ClientMetadata(
-            vpFormats: ["format1": [ "type1": ["value1"] ]],
-            jwks: JWKSet(keys: [
-                try convertToInstance([
-                    "kty": "OKP",
-                    "crv": "Ed25519",
-                    "use": "sig",
-                    "alg": "EdDSA",
-                    "kid": "ed-key1",
-                    "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
-                    "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
-                ], as: JWK.self),
-                try convertToInstance([
-                    "kty": "OKP",
-                    "crv": "Ed25519",
-                    "alg": "EdDSA",
-                    "use": "sig",
-                    "kid": "ed-key2",
-                    "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvuyfwqef",
-                    "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
-                ], as: JWK.self)
-            ])
-        ))
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
-            paramList: authRequestWithPreRegisteredByValueDraft23,
-            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
-        ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
-            trustedVerifiers: [trustedVerifier],
-            authorizationRequestParameters: authorizationRequestParameters,
-            walletMetadata: walletMetadata,
-            shouldValidateClient: true,
-            setResponseUri: mockSetResponseUri,
-            walletNonce: "mock-nonce",
-            networkManager: mockNetworkManager!
-        )
-        
-        
-        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "EdDSA")) { error in
-            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Multiple ambiguous keys found for EdDSA with signature usage", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
-        }
-    }
-    
-    func testExtractPublicKeyThrowsWhenClientMetadataInAuthRequest() async throws {
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
-            paramList: authRequestWithPreRegisteredByValueDraft23 + ["client_metadata"],
-            requestParams: authorizationRequestParamsWithValue
         ) as [String : Any]
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
             trustedVerifiers: preRegisteredVerifiers,
@@ -405,8 +222,110 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager!
         )
-        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")) { error in
-            assertOpenID4VPException(error, expectedMessage: "client_metadata available in Authorization Request, cannot be used to verify the signed Authorization Request", expectedCode: OpenID4VPErrorCodes.invalidRequest)
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: jwkSet)
+        
+        let publicKey = try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "Ed25519")
+        
+        assertPublicKey(expectedBase64Encoded: "5tvU4k/TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc=", actualKey: publicKey)
+    }
+    
+    func testExtractPublicKeySuccessForAlgorithmAndUsage() async throws {
+        let trustedVerifier = Verifier(clientId: "mock-client", responseUris: ["/response-uri"], jwksUri: jwksUri)
+        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValueDraft23,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
+        ) as [String : Any]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            trustedVerifiers: [trustedVerifier],
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletMetadata: walletMetadata,
+            shouldValidateClient: true,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager!
+        )
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: jwkSet)
+        
+        
+        await XCTAssertNoThrowAndVerifyAsync(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "EdDSA")) { publicKey in
+            assertPublicKey(expectedBase64Encoded: "5tvU4k/TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc=", actualKey: publicKey)
+        }
+    }
+    
+    func testExtractPublicKeyThrowErrorWhenAlgorithmAndKeyUsageDoesNotMatchInAvailableJWKS() async throws {
+        let trustedVerifier = Verifier(clientId: "mock-client", responseUris: ["/response-uri"], jwksUri: "https://mock-verifier.com/jwks.json")
+        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValueDraft23,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
+        ) as [String : Any]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            trustedVerifiers: [trustedVerifier],
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletMetadata: walletMetadata,
+            shouldValidateClient: true,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager!
+        )
+        mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/jwks.json", responseBody: """
+{
+"keys": [{
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "use": "sig",
+                    "alg": "ES256",
+                    "kid": "ec-key1",
+                    "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                    "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+}]
+}
+""")
+        
+        
+        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "Ed25519")) { error in
+            assertOpenID4VPException(error, expectedMessage: "No public key found for algorithm: Ed25519 with key use: signature", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+        }
+    }
+    
+    func testExtractPublicKeyThrowErrorWhenMultipleEntriesAreFoundForAlgorithmAndUsage() async throws {
+        let trustedVerifier = Verifier(clientId: "mock-client", responseUris: ["/response-uri"], jwksUri: "https://mock-verifier.com/jwks.json")
+        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValueDraft23,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
+        ) as [String : Any]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            trustedVerifiers: [trustedVerifier],
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletMetadata: walletMetadata,
+            shouldValidateClient: true,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager!
+        )
+        mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/jwks.json", responseBody: """
+{
+"keys": [{
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "use": "sig",
+                    "alg": "EdDSA",
+                    "kid": "ed-key1",
+                    "x": "5tvU4k/TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc="
+                },
+                {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "use": "sig",
+                    "alg": "EdDSA",
+                    "kid": "ed-key2",
+                    "x": "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2o="
+                }]
+}
+""")
+        
+        
+        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "EdDSA")) { error in
+            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Multiple ambiguous keys found for EdDSA with signature usage", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
         }
     }
     
@@ -425,7 +344,7 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
             networkManager: mockNetworkManager!
         )
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")) { error in
-            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed for keyId = ed-key2, algorithm: ECDSA", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+            assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
         }
     }
 
@@ -444,36 +363,7 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
             networkManager: mockNetworkManager!
         )
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: nil, algorithm: "ECDSA")) { error in
-            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed for keyId = null, algorithm: ECDSA", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
-        }
-    }
-    
-    func testExtractPublicKeyThrowsWhenJwksNotAvailable() async throws {
-        let trustedVerifiers = [
-            Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], clientMetadata: ClientMetadata(vpFormats: [
-                "ldp_vp": [
-                    "proof_type": [
-                        "Ed25519Signature2018",
-                        "Ed25519Signature2020"
-                    ]
-                ]
-            ]))
-        ]
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(
-            paramList: authRequestWithPreRegisteredByValueDraft23,
-            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23)
-        ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
-            trustedVerifiers: trustedVerifiers,
-            authorizationRequestParameters: authorizationRequestParameters,
-            walletMetadata: walletMetadata,
-            shouldValidateClient: true,
-            setResponseUri: mockSetResponseUri,
-            walletNonce: "mock-nonce",
-            networkManager: mockNetworkManager!
-        )
-        await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "EdDSA")) { error in
-            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Either client_metadata not available or jwks not available in pre-registered client_metadata to verify the signed Authorization Request", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+            assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
         }
     }
     
@@ -491,6 +381,9 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager!
         )
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: jwkSet)
+        
+        
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "non-existent-key", algorithm: "RS256")) { error in
             assertOpenID4VPException(error, expectedMessage: "Public key extraction failed for kid: Optional(\"non-existent-key\")", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
         }
@@ -502,5 +395,4 @@ class PreRegisteredClientIdSchemeTests : XCTestCase {
         
         return decoded
     }
-
 }

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -103,11 +103,13 @@ class OpenID4VPTests: XCTestCase {
     //client_id_scheme = pre-registered, validation of client via shouldValidateClient
 
     func testAuthenticateVerifierWithShouldValidateClientFalse() async throws {
-        await XCTAssertAsyncNoThrowsError(try await openID4VP.authenticateVerifier(
+        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(
             urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier,
             trustedVerifierJSON: preRegisteredVerifiers,
             shouldValidateClient: false
-        ), "should not throw even though the client ID isn't in the trusted list because shouldValidateClient is false")
+        ), "should not throw even though the client ID isn't in the trusted list because shouldValidateClient is false") { error in
+            assertOpenID4VPException(error, expectedMessage: "Authorization Request Object must be a signed JWT", expectedCode: OpenID4VPErrorCodes.invalidRequest)
+        }
     }
 
     func testAuthenticateVerifierWithShouldValidateClientTrue() async throws {
@@ -152,7 +154,7 @@ class OpenID4VPTests: XCTestCase {
             """.data(using: .utf8)!
         let clientMetadata = try ClientMetadata.deserializeAndValidate(clientMetadata: clientMetadataString)
         
-        let trustedVerifiers = [Verifier(clientId: "mock-client-id", responseUris: ["https://example.com/callback"], clientMetadata: clientMetadata)]
+        let trustedVerifiers = [Verifier(clientId: "mock-client-id", responseUris: ["https://example.com/callback"], jwksUri: "https://mock-verifier.com/.well-known/jwks.json")]
         await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(
             urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier,
             trustedVerifierJSON: trustedVerifiers,
@@ -184,7 +186,7 @@ class OpenID4VPTests: XCTestCase {
     //client_id_scheme = pre_registered, ClientMetadata mandatory values are not present
     func testMissingClientMetadataRequiredFieldsInRequest() async {
         let result = await Task {
-            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthorizationRequestWithInvalidClientMetadata, trustedVerifierJSON: preRegisteredVerifiers, shouldValidateClient: true)
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthorizationRequestWithInvalidClientMetadata, trustedVerifierJSON: [Verifier(clientId: "mock-client-2", responseUris: ["https://mock-verifier.com"], jwksUri: "https://mock-client.com/jwks", allowUnsignedRequest: true)], shouldValidateClient: true)
         }.result
 
         switch result {
@@ -203,7 +205,7 @@ class OpenID4VPTests: XCTestCase {
     func testShouldConstructAuthorizationRequestSuccessfullyWhenPresentationDefinitionIsSentByReference() async {
         mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/presentation-definition", responseBody: convertToJsonString(presentationDefinition))
         do {
-            let authorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthRequestWithPresentationDefinitionUri, trustedVerifierJSON: preRegisteredVerifiers, shouldValidateClient: false)
+            let authorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthRequestWithPresentationDefinitionUri, trustedVerifierJSON: preRegisteredVerifiers, shouldValidateClient: true)
             XCTAssertNotNil(authorizationRequest)
             XCTAssertEqual("mock-client", authorizationRequest.clientId)
         } catch {
@@ -449,6 +451,7 @@ class OpenID4VPTests: XCTestCase {
             trustedVerifierJSON: preRegisteredVerifiers,
             shouldValidateClient: true
         )
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: jwkSet)
         openID4VP.authorizationRequest = authorizationRequest
 
         

--- a/Tests/OpenID4VPTests/TestData/TestData.swift
+++ b/Tests/OpenID4VPTests/TestData/TestData.swift
@@ -2,6 +2,24 @@ import OpenID4VP
 import CryptoKit
 import Foundation
 
+let jwkSet = """
+            { "keys": [
+                    { 
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "use": "sig",
+                    "x": "5tvU4k_TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc",
+                    "alg": "EdDSA",
+                    "kid": "ed-key2" 
+                    },
+                {"kty": "OKP",
+                "crv": "X25519",
+                "use": "enc",
+                "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+                "alg": "ECDH-ES",
+                "kid": "ed-key1"}] }
+"""
+
 let clientMetadataString = """
         {
             "client_name": "Valid Client",
@@ -9,16 +27,19 @@ let clientMetadataString = """
             "authorization_encrypted_response_alg": "RSA-OAEP",
             "authorization_encrypted_response_enc": "A256GCM",
             "vp_formats": { "format1": { "type1": ["value1"] } },
-            "jwks": { "keys": [{ "kty": "RSA", "crv": "P-256", "use": "sig", "alg": "RS256", "kid": "1", "x": "ur76rg" }] }
+            "jwks": \(jwkSet)
         }
     """.data(using: .utf8)!
+
+let jwksUri = "https://mock-verifier.com/.well-known/jwks.json"
 
 private let testVerifierList:  [[String: Any]]  = [
     [
         "client_id": "https://mock-verifier.com",
         "response_uris": [
             "https://mock-verifier.com/response",
-        ]
+        ],
+        "allow_unsigned_request": true,
     ],
     [
         "client_id": "mock-client-2",
@@ -31,7 +52,8 @@ private let testVerifierList:  [[String: Any]]  = [
         "response_uris": [
             "https://mock-verifier.com",
         ],
-        "client_metadata": clientMetadata
+        "jwks_uri": "https://mock-verifier.com/.well-known/jwks.json",
+        "allow_unsigned_request": true,
     ]
 ]
 
@@ -161,7 +183,8 @@ let authRequestWithPreRegisteredByValueDraft23 : [String] = [
     "presentation_definition",
     "response_type",
     "nonce",
-    "state"
+    "state",
+    "client_metadata"
 ]
 
 let authRequestWithPreRegisteredByValueDraft21 : [String] = [
@@ -308,7 +331,7 @@ let testVPRequestWithRedirectUriAndClientIdNotEqual = createUrlEncodedAuthorizat
 //client_id_scheme = pre-registered
 let testValidUrlEncodedVPRequestWithResponseUri = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft23), clientIdScheme: .preRegistered)
 
-let testUrlEncodedAuthRequestOfUntrustedVerifier = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted_client"]), clientIdScheme: .preRegistered)
+let testUrlEncodedAuthRequestOfUntrustedVerifier = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted_client"]), verifierSentAuthRequestByReference: true, clientIdScheme: .preRegistered)
 
 // client_id_scheme = pre-registered draft 21
 let testValidUrlEncodedVPRequestWithResponseUriDraft21 = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdDraft21), clientIdScheme: .preRegistered, draftVersion: 21)
@@ -337,7 +360,7 @@ let invalidJwtResponseWithoutKid = createAuthorizationRequestObject(clientIdSche
 let resquestUriResponseData: [String: Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdDraft23)) as [String : Any]
 
 let mockUrlEncodedVPRequestWithDirectPostJwt = createUrlEncodedAuthorizationRequest(
-    requestParams: mergeMaps(authorizationRequestParamsWithValue.merging(["response_mode": "direct_post.jwt"]) { _, new in new },preRegisteredSchemeClientIdDraft23).filter{$0.key != "client_metadata"},clientIdScheme: .preRegistered
+    requestParams: mergeMaps(authorizationRequestParamsWithValue.merging(["response_mode": "direct_post.jwt"]) { _, new in new },preRegisteredSchemeClientIdDraft23),clientIdScheme: .preRegistered
 )
 
 let mockAuthorizationRequestObjectWithDirectPostResponseMode = getMockAuthorizationRequest()

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -8,15 +8,16 @@ func createVerifiers(from verifierList: [[String: Any]]) -> [Verifier] {
     for verifierData in verifierList {
         if let clientId = verifierData[AuthorizationRequestFieldConstants.clientId.rawValue] as? String,
            let responseUris = verifierData["response_uris"] as? [String] {
-            if verifierData["client_metadata"] == nil {
-                let verifier = Verifier(clientId: clientId, responseUris: responseUris)
+            let jwksUri = verifierData["jwks_uri"] as? String
+            
+            if let allowUnsignedRequest = verifierData["allow_unsigned_request"] as? Bool {
+                let verifier = Verifier(clientId: clientId, responseUris: responseUris, jwksUri: jwksUri, allowUnsignedRequest: allowUnsignedRequest)
                 verifiers.append(verifier)
-            } else {
-                let clientMetadataData = verifierData["client_metadata"] as! [String: Any]
-                let clientMetadata = createInstance(clientMetadataData, as: ClientMetadata.self)
-                let verifier = Verifier(clientId: clientId, responseUris: responseUris, clientMetadata: clientMetadata)
-                verifiers.append(verifier)
+                continue
             }
+            let verifier = Verifier(clientId: clientId, responseUris: responseUris)
+            verifiers.append(verifier)
+            
         }
     }
     


### PR DESCRIPTION
**Changes include**
- Access trusted verifiers list with verifier having `jwks_uri` and `allowUnsignedRequest ` along with already existing params
      - This `jwks_uri` will be the Verifier's uri where their JWKs is hosted
          - usecase: This will further be used for verifying the pre-registered Verifiers signed Authorization Request
     - This `allowUnsignedRequest` will decide whether the particular verifier supports unsigned request (as of now Authorization request by value mode) or not. With the help of this param, the Wallet can control the security of the transaction / OVP flow with pre-registered verifiers
     - By default `allowUnsignedRequest` is kept as false
- ClientMetadata has been removed from the trusted verifer

Affected flows
- Pre-registered client id scheme
- Now, Authorization request by reference mode's signed request will be verified using the `jwks_uri` available in the trusted verifers list passed as an argument to the `authenticateVerifier` method