### PR TITLE
[INJIMOB-3550] add: sendAuthorizationResponseToVerifier method

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ The following methods are deprecated and will be removed in future releases. Ple
 | Method Name                 | Description                                   | Deprecated Since | Suggested Alternative                                                       |
 |-----------------------------|-----------------------------------------------|------------------|-----------------------------------------------------------------------------|
 | shareVerifiablePresentation | Sends VP (Authorization response) to verifier | 0.6.0            | [sendAuthorizationResponseToVerifier](#sendauthorizationresponsetoverifier) |
-| sendErrorToVerifier         | Sends Authorization error to the verifier     | 0.6.0            | [sendErrorResponseToVerifier](#sendErrorResponseToVerifier)                 |
+| sendErrorToVerifier         | Sends Authorization error to the verifier     | 0.6.0            | [sendErrorResponseToVerifier](#senderrorresponsetoverifier)                 |
 
 ## Architecture decisions
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ inji-openid4vp-ios-swift is an implementation of OpenID for Verifiable Presentat
 - [APIs](#apis)
   - [authenticateVerifier](#authenticateverifier)
   - [constructUnsignedVPToken](#constructUnsignedVPToken)
-  - [shareVerifiablePresentation](#shareverifiablepresentation)
-  - [sendErrorToVerifier](#senderrortoverifier)
+  - [sendAuthorizationResponseToVerifier](#sendauthorizationresponsetoverifier)
+  - [sendErrorResponseToVerifier](#senderrorresponsetoverifier)
 
 ## OpenID4VP specification draft versions supported
 
@@ -353,7 +353,55 @@ let unsignedVPTokens: [FormatType: UnsignedVPToken] = try openID4VP.constructUns
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
-### shareVerifiablePresentation
+### sendAuthorizationResponseToVerifier
+- This function constructs a vp_token with proof using received VPTokenSigningResult, then sends it and the presentation_submission to the Verifier via a HTTP POST request.
+- Returns the response back to the consumer app(mobile app) saying whether it has received the shared Verifiable Credentials or not.
+
+```swift
+    let response = try await openID4VP.sendAuthorizationResponseToVerifier(vpTokenSigningResults: [FormatType:VPTokenSigningResult])
+```
+
+###### Parameters
+
+| Name                  | Type                               | Required | Default Value | Description                                                                                                                                                   |
+|-----------------------|------------------------------------|:---------|:--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| vpTokenSigningResults | [FormatType: VPTokenSigningResult] | Yes      | N/A           | This will be a map with key as credential format and value as VPTokenSigningResult (which is specific to respective credential format's required information) |
+
+
+###### Example usage
+
+```swift
+let ldpVPTokenSigningResult = LdpVPTokenSigningResult(
+    jws : createJWS(unsignedLdpVPToken),
+    signatureAlgorithm : "RsaSignature2018",
+    publicKey : "<publicKey>",
+    domain : "<domain>"
+)
+
+let mdocVPTokenSigningResult = MdocVPTokenSigningResult(
+    docTypeToDeviceAuthentication: [
+        "<docType>": DeviceAuthentication(
+            signature: createSignature(unsignedMdocVPToken.docTypeToDeviceAuthenticationBytes("<docType>")), 
+            algorithm: "<mdocAuthenticationAlgorithm>",
+        )
+    ]
+  )
+let vpTokenSigningResults : [FormatType: VPTokenSigningResult] = [FormatType.ldp_vc : ldpVPTokenSigningResult, FormatType.mso_mdoc: mdocVPTokenSigningResult]
+let response : NetworkResponse = try await openID4VP.sendAuthorizationResponseToVerifier(vpTokenSigningResults : vpTokenSigningResults)
+```
+
+###### Exceptions
+
+1. JsonEncodingFailed exception is thrown if there is any issue while serializing the generating vp_token or presentation_submission class instances.
+2. UnsupportedTypeDecoding exception is thrown when there is any issue in decoding the unsupported type.
+3. InterruptedIOException is thrown if the connection is timed out when network call is made.
+4. NetworkRequestFailed exception is thrown when there is any other exception occurred when sending the response over http post request.
+5. InvalidData exception is thrown if the response_type in the authorization request is not supported
+
+
+This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
+
+### shareVerifiablePresentation (deprecated, use sendAuthorizationResponseToVerifier instead)
 - This function constructs a vp_token with proof using received VPTokenSigningResult, then sends it and the presentation_submission to the Verifier via a HTTP POST request.
 - Returns the response back to the consumer app(mobile app) saying whether it has received the shared Verifiable Credentials or not.
 
@@ -410,7 +458,7 @@ This method will also notify the Verifier about the error by sending it to the r
 // Example: The user declines to share the requested credentials. In this case, Verifier needs to be informed about the scenario.
 // So call the sendErrorResponseToVerifier method with appropriate exception message to notify the Verifier.
 
-let verifierResponse: String = openID4VP.sendErrorResponseToVerifier(
+let verifierResponse: NetworkResponse = openID4VP.sendErrorResponseToVerifier(
         AccessDenied(
             message = "User did not give consent to share the requested Credentials with the Verifier.",
             className = this.className
@@ -444,17 +492,30 @@ await openID4VP.sendErrorToVerifier(error: AuthorizationConsent.consentRejectedE
 
 1. ErrorDispatchFailure is thrown if any issue occurs while sending the Authorization Error response to the Verifier.
 
-###### Exception Handling Enhancement
+## Exception Handling Enhancement
 
 - The library has been enhanced to handle exceptions more gracefully. Library is throwing `OpenID4VPException` now which gives both Error Code, Message and optional state to the consumer app. The `state` value is extracted from the authorization request and is included in the error response only if it is present and non-empty. This allows the consumer app to handle exceptions more effectively and provide better user experience.
+
+### OpenID4VPException structure
+
+OpenID4VPException is a custom exception class that extends the standard Exception class. It is used to represent errors specific to the OpenID4VP library.
+
+This exception has the following properties:
+
+1. errorCode: A unique code representing the type of error.
+2. message: A descriptive message providing details about the error.
+3. networkResponse: An optional property that holds the Verifier response obtained while sending the error to Verifier.
+4. className: The name of the class where the exception occurred.
+
 
 ## 🚨 Deprecation Notice
 
 The following methods are deprecated and will be removed in future releases. Please migrate to the suggested alternatives.
 
-| Method Name         | Description                               | Deprecated Since | Suggested Alternative                                       |
-|---------------------|-------------------------------------------|------------------|-------------------------------------------------------------|
-| sendErrorToVerifier | Sends Authorization error to the verifier | 0.6.0            | [sendErrorResponseToVerifier](#sendErrorResponseToVerifier) |
+| Method Name                 | Description                                   | Deprecated Since | Suggested Alternative                                                       |
+|-----------------------------|-----------------------------------------------|------------------|-----------------------------------------------------------------------------|
+| shareVerifiablePresentation | Sends VP (Authorization response) to verifier | 0.6.0            | [sendAuthorizationResponseToVerifier](#sendauthorizationresponsetoverifier) |
+| sendErrorToVerifier         | Sends Authorization error to the verifier     | 0.6.0            | [sendErrorResponseToVerifier](#sendErrorResponseToVerifier)                 |
 
 ## Architecture decisions
 

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
@@ -78,6 +78,9 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerBaseClass  {
             var response:  NetworkResponse
             do{
                 response = try await networkManager.sendHTTPRequest(url: requestUri, method: httpMethod, bodyParams: body, headers: headers)
+                if(response.statusCode != 200){
+                    throw InvalidData(message: "Error while fetching request_uri: HTTP status code \(response.statusCode) & body: \(response.body)", className: className)
+                }
             }
             catch let error as NetworkRequestException {
                 let isMismatchedAcceptableType = error.localizedDescription.contains(errorMessageForMismatchedAcceptableType)

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
@@ -78,7 +78,7 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerBaseClass  {
             var response:  NetworkResponse
             do{
                 response = try await networkManager.sendHTTPRequest(url: requestUri, method: httpMethod, bodyParams: body, headers: headers)
-                if(response.statusCode != 200){
+                if(!response.isOK){
                     throw InvalidData(message: "Error while fetching request_uri: HTTP status code \(response.statusCode) & body: \(response.body)", className: className)
                 }
             }

--- a/Sources/OpenID4VP/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtil.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtil.swift
@@ -88,6 +88,12 @@ func parseAndValidatePresentationDefinition(
             response = try await networkManager.sendHTTPRequest(
                 url: uriString, method: .get, bodyParams: nil, headers: nil
             )
+            if(response.statusCode != 200){
+                throw InvalidData(
+                    message: "Error while fetching presentation_definition from presentation_definition_uri: \(uriString), status code: \(response.statusCode) with body: \(response.body)",
+                    className: AuthorizationRequest.className
+                )
+            }
         } catch {
             throw InvalidData(
                 message: "presentation_definition_uri could not be reached: \(uriString)",

--- a/Sources/OpenID4VP/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtil.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtil.swift
@@ -88,7 +88,7 @@ func parseAndValidatePresentationDefinition(
             response = try await networkManager.sendHTTPRequest(
                 url: uriString, method: .get, bodyParams: nil, headers: nil
             )
-            if(response.statusCode != 200){
+            if(!response.isOK){
                 throw InvalidData(
                     message: "Error while fetching presentation_definition from presentation_definition_uri: \(uriString), status code: \(response.statusCode) with body: \(response.body)",
                     className: AuthorizationRequest.className

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -122,7 +122,7 @@ public class AuthorizationResponseHandler {
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: [FormatType: VPTokenSigningResult],
         responseUri: String
-    ) async throws -> String {
+    ) async throws -> NetworkResponse {
         let authorizationResponse = try createAuthorizationResponse(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults
@@ -240,7 +240,7 @@ public class AuthorizationResponseHandler {
         authorizationRequest: AuthorizationRequest,
         authorizationResponse: AuthorizationResponse,
         responseUri: String
-    ) async throws -> String {
+    ) async throws -> NetworkResponse {
         return try await ResponseModeBasedHandlerFactory.get(responseMode: authorizationRequest.responseMode)
             .sendAuthorizationResponse(
                 authorizationRequest: authorizationRequest,

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -248,7 +248,7 @@ public class AuthorizationResponseHandler {
                 url: responseUri,
                 networkManager: networkManager,
                 producerInfo:walletNonce,
-                recepientInfo: authorizationRequest.nonce
+                recipientInfo: authorizationRequest.nonce
             )
     }
     

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -75,7 +75,7 @@ public class AuthorizationResponseHandler {
         return unsignedVPTokensExtracted
     }
     
-    func sendAuthorizationError(responseUri: String?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> String {
+    func sendAuthorizationError(responseUri: String?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> NetworkResponse {
         guard let responseUri = responseUri, !responseUri.isEmpty else {
             throw ErrorDispatchFailure(message: "Response URI is not set. Cannot send error to verifier.", className: Self.className)
         }        
@@ -107,8 +107,8 @@ public class AuthorizationResponseHandler {
                 bodyParams: errorPayload,
                 headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
             )
-            (error as? OpenID4VPException)?.setResponse(dispatchResult.body)
-            return dispatchResult.body
+            (error as? OpenID4VPException)?.setNetworkResponse(dispatchResult)
+            return dispatchResult
         } catch {
             throw ErrorDispatchFailure(
                 message: "Failed to send error to verifier: \(error)",

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -124,7 +124,7 @@ func createDescriptorMapPath(_ index: Int) -> String {
 func resolveJwksFromUri(_ uri: String, networkManager: NetworkManaging, className: String) async throws -> JWKSet {
     do {
         let response = try await networkManager.sendHTTPRequest(url: uri, method: .get, bodyParams: nil, headers: nil)
-        if(response.statusCode != 200){
+        if(!response.isOK){
             throw InvalidData(
                 message: "Error while fetching jwks information, status code: \(response.statusCode) with body: \(response.body)",
                 className: AuthorizationRequest.className

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -124,11 +124,16 @@ func createDescriptorMapPath(_ index: Int) -> String {
 func resolveJwksFromUri(_ uri: String, networkManager: NetworkManaging, className: String) async throws -> JWKSet {
     do {
         let response = try await networkManager.sendHTTPRequest(url: uri, method: .get, bodyParams: nil, headers: nil)
+        if(response.statusCode != 200){
+            throw InvalidData(
+                message: "Error while fetching jwks information, status code: \(response.statusCode) with body: \(response.body)",
+                className: AuthorizationRequest.className
+            )
+        }
         let data = try response.body.data(using: .utf8) ?? {
            throw InvalidData(
                 message: "unable to convert the jwks response to data",
-                className: className,
-                code: OpenID4VPErrorCodes.invalidRequestObject
+                className: className
             )
         }()
         return try data.toInstance(as: JWKSet.self)

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -127,7 +127,7 @@ func resolveJwksFromUri(_ uri: String, networkManager: NetworkManaging, classNam
         if(!response.isOK){
             throw InvalidData(
                 message: "Error while fetching jwks information, status code: \(response.statusCode) with body: \(response.body)",
-                className: AuthorizationRequest.className
+                className: className
             )
         }
         let data = try response.body.data(using: .utf8) ?? {

--- a/Sources/OpenID4VP/Constants/NetworkManagerConstants.swift
+++ b/Sources/OpenID4VP/Constants/NetworkManagerConstants.swift
@@ -13,3 +13,8 @@ public enum ContentTypes : String {
     case applicationJwt = "application/oauth-authz-req+jwt"
     case applicationFormUrlEncoded = "application/x-www-form-urlencoded"
 }
+
+
+public enum StatusCodes : Int {
+    case ok = 200
+}

--- a/Sources/OpenID4VP/Constants/NetworkManagerConstants.swift
+++ b/Sources/OpenID4VP/Constants/NetworkManagerConstants.swift
@@ -17,4 +17,5 @@ public enum ContentTypes : String {
 
 public enum StatusCodes : Int {
     case ok = 200
+    case multipleChoices = 300
 }

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -5,7 +5,7 @@ public class OpenID4VPException: Error, CustomStringConvertible, LocalizedError 
     public let message: String
     public let className: String
     // holds the response received from the Verifier if the error is sent to the Verifier
-    public var networkResponse: NetworkResponse? = nil
+    public var networkResponse: NetworkResponse?
     
     internal func setNetworkResponse(_ response: NetworkResponse) {
         self.networkResponse = response

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -4,11 +4,11 @@ public class OpenID4VPException: Error, CustomStringConvertible, LocalizedError 
     public let errorCode: String
     public let message: String
     public let className: String
-    // holds the response body received from the Verifier if the error is sent to the Verifier
-    public var response: String? = nil
+    // holds the response received from the Verifier if the error is sent to the Verifier
+    public var networkResponse: NetworkResponse? = nil
     
-    internal func setResponse(_ responseBody: String) {
-        self.response = responseBody
+    internal func setNetworkResponse(_ response: NetworkResponse) {
+        self.networkResponse = response
     }
     
     private static var logTag = ""

--- a/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
@@ -60,7 +60,18 @@ public struct NetworkManager: NetworkManaging {
                         let exception = NetworkRequestException.networkRequestTimeout
                         OpenID4VPException.error(NetworkManager.logTag, exception)
                         continuation.resume(throwing: exception)
-                    } else {
+                    }
+                    if let statusCode = response.response?.statusCode {
+                        let message = HTTPURLResponse.localizedString(forStatusCode: statusCode)
+                        let response = NetworkResponse(
+                            statusCode: statusCode,
+                            body: response.data.flatMap { String(data: $0, encoding: .utf8) } ?? "",
+                            headers: response.response?.headers.dictionary ?? [:]
+                        )
+                        continuation.resume(returning: response)
+                        return
+                    }
+                    else {
                         let exception = NetworkRequestException.networkRequestFailed(message: "\(error.localizedDescription)")
                         OpenID4VPException.error(NetworkManager.logTag, exception)
                         continuation.resume(throwing: exception)
@@ -71,7 +82,7 @@ public struct NetworkManager: NetworkManaging {
     }
     
     private func getEncoding(for contentType: String?) -> ParameterEncoding {
-            return URLEncoding.default
+        return URLEncoding.default
     }
     
     private func formatRequestBody(_ body: [String: String]?, for contentType: String?) -> Parameters {

--- a/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
@@ -5,6 +5,11 @@ public struct NetworkResponse : Codable {
     public let statusCode: Int
     public let body: String
     public let headers: [String: String]
+    
+    var isOK: Bool {
+        return statusCode == StatusCodes.ok.rawValue
+        
+    }
 }
 
 public struct NetworkManager: NetworkManaging {

--- a/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
@@ -1,10 +1,10 @@
 import Foundation
 import Alamofire
 
-public struct NetworkResponse {
-    let statusCode: Int
-    let body: String
-    let headers: HTTPURLResponse
+public struct NetworkResponse : Codable {
+    public let statusCode: Int
+    public let body: String
+    public let headers: [String: String]
 }
 
 public struct NetworkManager: NetworkManaging {
@@ -47,7 +47,7 @@ public struct NetworkManager: NetworkManaging {
                         let networkResponse = NetworkResponse(
                             statusCode: httpResponse.statusCode,
                             body: responseBody,
-                            headers: httpResponse
+                            headers: httpResponse.headers.dictionary
                         )
                         continuation.resume(returning: networkResponse)
                     } else {

--- a/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
+++ b/Sources/OpenID4VP/NetworkManager/NetworkManager.swift
@@ -7,7 +7,7 @@ public struct NetworkResponse : Codable {
     public let headers: [String: String]
     
     var isOK: Bool {
-        return statusCode == StatusCodes.ok.rawValue
+        return statusCode >= StatusCodes.ok.rawValue && statusCode < StatusCodes.multipleChoices.rawValue
         
     }
 }

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -83,9 +83,9 @@ public class OpenID4VP {
         }
     }
     
-    public func shareVerifiablePresentation(
+    public func sendAuthorizationResponseToVerifier(
         vpTokenSigningResults: [FormatType: VPTokenSigningResult]
-    ) async throws -> String {
+    ) async throws -> NetworkResponse {
         do {
             return try await authorizationResponseHandler.shareVP(
                 authorizationRequest: authorizationRequest,
@@ -96,6 +96,13 @@ public class OpenID4VP {
             await safeSendError(error: error)
             throw error
         }
+    }
+    
+    @available(*, deprecated, renamed: "sendAuthorizationResponseToVerifier", message: "This method does not support listening to the status code sent from the verifier. Replace with sendAuthorizationResponseToVerifier(vpTokenSigningResults)")
+    public func shareVerifiablePresentation(
+        vpTokenSigningResults: [FormatType: VPTokenSigningResult]
+    ) async throws -> String {
+        return try await self.sendAuthorizationResponseToVerifier(vpTokenSigningResults: vpTokenSigningResults).body
     }
     
     public func sendErrorResponseToVerifier(error: Error) async throws -> String {

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -98,24 +98,24 @@ public class OpenID4VP {
         }
     }
     
-    @available(*, deprecated, renamed: "sendAuthorizationResponseToVerifier", message: "This method does not support listening to the status code sent from the verifier. Replace with sendAuthorizationResponseToVerifier(vpTokenSigningResults)")
-    public func shareVerifiablePresentation(
-        vpTokenSigningResults: [FormatType: VPTokenSigningResult]
-    ) async throws -> String {
-        return try await self.sendAuthorizationResponseToVerifier(vpTokenSigningResults: vpTokenSigningResults).body
-    }
-    
-    public func sendErrorResponseToVerifier(error: Error) async throws -> String {
+    public func sendErrorResponseToVerifier(error: Error) async throws -> NetworkResponse {
        return try await authorizationResponseHandler.sendAuthorizationError(responseUri: self.responseUri, authorizationRequest: self.authorizationRequest, error: error)
     }
     
     private func safeSendError(error: Error) async {
         do {
             let verifierResponse = try await sendErrorResponseToVerifier(error: error)
-            (error as? OpenID4VPException)?.setResponse(verifierResponse)
+            (error as? OpenID4VPException)?.setNetworkResponse(verifierResponse)
         } catch {
             OpenID4VPException.error(error, className: className)
         }
+    }
+    
+    @available(*, deprecated, renamed: "sendAuthorizationResponseToVerifier", message: "This method does not support listening to the status code sent from the verifier. Replace with sendAuthorizationResponseToVerifier(vpTokenSigningResults)")
+    public func shareVerifiablePresentation(
+        vpTokenSigningResults: [FormatType: VPTokenSigningResult]
+    ) async throws -> String {
+        return try await self.sendAuthorizationResponseToVerifier(vpTokenSigningResults: vpTokenSigningResults).body
     }
     
     @available(*, deprecated, message: "Use authenticateVerifier without WalletMetadata instead. Reason: WalletMetadata is moved to OpenID4VP constructor instead of being passed as parameter")

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -10,7 +10,7 @@ protocol ResponseModeBasedHandler {
                                    networkManager: NetworkManaging,
                                    producerInfo: String,
                                    recepientInfo: String
-    ) async throws -> String
+    ) async throws -> NetworkResponse
     func setResponseUrl(authorizationRequestParameters: [String : Any], setResponseUri: (String) -> Void) throws
 }
 

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -9,7 +9,7 @@ protocol ResponseModeBasedHandler {
                                    url: String,
                                    networkManager: NetworkManaging,
                                    producerInfo: String,
-                                   recepientInfo: String
+                                   recipientInfo: String
     ) async throws -> NetworkResponse
     func setResponseUrl(authorizationRequestParameters: [String : Any], setResponseUri: (String) -> Void) throws
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -71,12 +71,12 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
     }
 
     func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest, authorizationResponse: AuthorizationResponse, url: String, networkManager: any NetworkManaging, producerInfo: String,
-                                   recepientInfo: String) async throws -> NetworkResponse {
+                                   recipientInfo: String) async throws -> NetworkResponse {
         let bodyParams = try authorizationResponse.toJsonEncodedMap()
         let clientMetadata = (authorizationRequest.clientMetadata)!
         let verifierPublicKey = try getJwk(clientMetadata.jwks!, clientMetadata.authorizationEncryptedResponseAlg!)
 
-        let encryptedBody = try JWEHandler(contentEncryptionAlgorithm: clientMetadata.authorizationEncryptedResponseEnc!, keyEncryptionAlgorithm: clientMetadata.authorizationEncryptedResponseAlg!, publicKey: verifierPublicKey, producerInfo: producerInfo, recipientInfo: recepientInfo).generateEncryptedResponse(payload: bodyParams)
+        let encryptedBody = try JWEHandler(contentEncryptionAlgorithm: clientMetadata.authorizationEncryptedResponseEnc!, keyEncryptionAlgorithm: clientMetadata.authorizationEncryptedResponseAlg!, publicKey: verifierPublicKey, producerInfo: producerInfo, recipientInfo: recipientInfo).generateEncryptedResponse(payload: bodyParams)
 
         let requestBody = ["response": encryptedBody]
         let response = try await networkManager.sendHTTPRequest(url: url, method: .post, bodyParams: requestBody, headers: [Header.contentType.rawValue : ContentTypes.applicationFormUrlEncoded.rawValue])

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -71,7 +71,7 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
     }
 
     func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest, authorizationResponse: AuthorizationResponse, url: String, networkManager: any NetworkManaging, producerInfo: String,
-    recepientInfo: String) async throws -> String {
+                                   recepientInfo: String) async throws -> NetworkResponse {
         let bodyParams = try authorizationResponse.toJsonEncodedMap()
         let clientMetadata = (authorizationRequest.clientMetadata)!
         let verifierPublicKey = try getJwk(clientMetadata.jwks!, clientMetadata.authorizationEncryptedResponseAlg!)
@@ -81,7 +81,7 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
         let requestBody = ["response": encryptedBody]
         let response = try await networkManager.sendHTTPRequest(url: url, method: .post, bodyParams: requestBody, headers: [Header.contentType.rawValue : ContentTypes.applicationFormUrlEncoded.rawValue])
 
-        return response.body
+        return response
     }
 
     private func getJwk(_ jwks: JWKSet, _ alg: String) throws -> JWK {

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -17,14 +17,12 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
     ) async throws -> NetworkResponse {
         let requestBody: [String: String] = try authorizationResponse.toJsonEncodedMap()
 
-        let response = try await networkManager.sendHTTPRequest(
+        return try await networkManager.sendHTTPRequest(
             url: url,
             method: .post,
             bodyParams: requestBody,
             headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
         )
-
-        return response
     }
 
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -13,7 +13,7 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
         url: String,
         networkManager: any NetworkManaging,
         producerInfo: String,
-        recipientInfo recipientInfo: String
+        recipientInfo: String
     ) async throws -> NetworkResponse {
         let requestBody: [String: String] = try authorizationResponse.toJsonEncodedMap()
 

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -13,7 +13,7 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
         url: String,
         networkManager: any NetworkManaging,
         producerInfo: String,
-        recepientInfo recipientInfo: String
+        recipientInfo recipientInfo: String
     ) async throws -> NetworkResponse {
         let requestBody: [String: String] = try authorizationResponse.toJsonEncodedMap()
 

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -14,7 +14,7 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
         networkManager: any NetworkManaging,
         producerInfo: String,
         recepientInfo recipientInfo: String
-    ) async throws -> String {
+    ) async throws -> NetworkResponse {
         let requestBody: [String: String] = try authorizationResponse.toJsonEncodedMap()
 
         let response = try await networkManager.sendHTTPRequest(
@@ -24,7 +24,7 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
             headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
         )
 
-        return response.body
+        return response
     }
 
 }

--- a/Sources/OpenID4VP/jwt/KeyResolver/types/did/DidWebResolver.swift
+++ b/Sources/OpenID4VP/jwt/KeyResolver/types/did/DidWebResolver.swift
@@ -20,7 +20,7 @@ class DidWebResolver : BaseDidPublicKeyResolver {
             
             let response = try await networkManager.sendHTTPRequest(url: urlString, method: .get, bodyParams: nil, headers: nil)
             
-            if(response.statusCode != 200){
+            if(!response.isOK){
                 throw InvalidData(
                     message: "Error while resolving did, status code: \(response.statusCode) with body: \(response.body)",
                     className: AuthorizationRequest.className

--- a/Sources/OpenID4VP/jwt/KeyResolver/types/did/DidWebResolver.swift
+++ b/Sources/OpenID4VP/jwt/KeyResolver/types/did/DidWebResolver.swift
@@ -19,6 +19,13 @@ class DidWebResolver : BaseDidPublicKeyResolver {
             let urlString = constructDIDUrl(from: parsedDID)
             
             let response = try await networkManager.sendHTTPRequest(url: urlString, method: .get, bodyParams: nil, headers: nil)
+            
+            if(response.statusCode != 200){
+                throw InvalidData(
+                    message: "Error while resolving did, status code: \(response.statusCode) with body: \(response.body)",
+                    className: AuthorizationRequest.className
+                )
+            }
             guard let responseBody = response.body.data(using: .utf8) else {
                 throw InvalidData(
                     message: "Conversion failed: resolved DID response body could not be encoded",

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
@@ -86,6 +86,23 @@ class ClientIdSchemeBasedAuthorizationRequestTests : XCTestCase {
         }
     }
     
+    func testThrowExceptionWhenRequestUriResponseIsNot200() async {
+        let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReferenceDraft23 , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdDraft23)) as [String : Any]
+        
+        let requestUriResponse = createRequestUriResponse("{\"message\" : \"Invalid request\"}", httpUrlResponse: HTTPURLResponse(url: requestUri, statusCode: 400, httpVersion: "", headerFields: ["Content-Type": "application/json"])!)
+        mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/verifier/get-auth-request-obj",response: (responseBody: requestUriResponse.body, httpUrlResponse: requestUriResponse.httpUrlResponse))
+        
+        let mockAuthHandler = MockClientIdSchemeAuthRequestHandler(authorizationRequestParameters: authorizationRequestParametersByReference, walletMetadata: walletMetadata, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        
+        
+        await XCTAssertAsyncThrowsError(try await mockAuthHandler.fetchAuthorizationRequest()){ error in
+            assertOpenID4VPException(error,
+                                     expectedMessage: "Unknown error occurred Error while fetching request_uri: Error while fetching request_uri: HTTP status code 400 & body: {\"message\" : \"Invalid request\"}",
+                                     expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+                                                          }
+    
     func testThrowExceptionWhenRequestUriResponseContentTypeIsNotJWT() async {
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReferenceDraft23 , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdDraft23)) as [String : Any]
         

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
@@ -86,7 +86,7 @@ class ClientIdSchemeBasedAuthorizationRequestTests : XCTestCase {
         }
     }
     
-    func testThrowExceptionWhenRequestUriResponseIsNot200() async {
+    func testThrowExceptionWhenRequestUriResponseIsNot2xx() async {
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReferenceDraft23 , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdDraft23)) as [String : Any]
         
         let requestUriResponse = createRequestUriResponse("{\"message\" : \"Invalid request\"}", httpUrlResponse: HTTPURLResponse(url: requestUri, statusCode: 400, httpVersion: "", headerFields: ["Content-Type": "application/json"])!)

--- a/Tests/OpenID4VPTests/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtilTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtilTests.swift
@@ -181,4 +181,24 @@ final class PresentationDefinitionUtilTests: XCTestCase {
                 )
             }
     }
+    
+    func testThrowErrorWhenPresentationDefinitionUriRespondsWithNon200Response() async {
+        let presentationDefinitionUri = "https://mock-verifier.com/verifier/presentation-definition"
+        let authorizationRequest = [
+            "presentation_definition_uri": presentationDefinitionUri,
+            // other request params
+        ]
+        let requestUriResponse = createRequestUriResponse("{\"message\" : \"Invalid request\"}", httpUrlResponse: HTTPURLResponse(url: requestUri, statusCode: 400, httpVersion: "", headerFields: ["Content-Type": "application/json"])!)
+        networkManager.setMockResponse(for: presentationDefinitionUri,response: (responseBody: requestUriResponse.body, httpUrlResponse: requestUriResponse.httpUrlResponse))
+            
+        
+        
+        await XCTAssertAsyncThrowsError(try await parseAndValidatePresentationDefinition(authorizationRequest, isPresentationDefinitionUriSupported, networkManager)) { error in
+            assertOpenID4VPException(error,
+                expectedMessage: "presentation_definition_uri could not be reached: https://mock-verifier.com/verifier/presentation-definition",
+                expectedCode: OpenID4VPErrorCodes.invalidPresentationDefinitionUri
+            )
+        }
+        
+    }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtilTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtilTests.swift
@@ -182,7 +182,7 @@ final class PresentationDefinitionUtilTests: XCTestCase {
             }
     }
     
-    func testThrowErrorWhenPresentationDefinitionUriRespondsWithNon200Response() async {
+    func testThrowErrorWhenPresentationDefinitionUriRespondsWithNon2xxResponse() async {
         let presentationDefinitionUri = "https://mock-verifier.com/verifier/presentation-definition"
         let authorizationRequest = [
             "presentation_definition_uri": presentationDefinitionUri,

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -115,7 +115,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             responseUri: responseUri
         )
         
-        XCTAssertEqual(result, "sending is success in AuthorizationResponseTests")
+        XCTAssertEqual(result.body, "sending is success in AuthorizationResponseTests")
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertEqual(recordedRequest.requestBody?["state"] as? String, state)
         XCTAssertNotNil(recordedRequest.requestBody?["presentation_submission"])
@@ -153,7 +153,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             responseUri: responseUri
         )
         
-        XCTAssertEqual(result, "sending is success in AuthorizationResponseTests")
+        XCTAssertEqual(result.body, "sending is success in AuthorizationResponseTests")
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertEqual(recordedRequest.requestBody?.keys.count, 1)
         XCTAssertNotNil(recordedRequest.requestBody?["response"])
@@ -367,7 +367,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let result = try await handler.shareVP(authorizationRequest: authorizationRequest, vpTokenSigningResults: [.vc_sd_jwt: SdJwtVpTokenSigningResult(uuidToKbJWTSignature: [sdJwtUUID: "ayuht"])], responseUri: responseUri)
 
 
-        XCTAssertEqual(result, "sending is success in AuthorizationResponseTests")
+        XCTAssertEqual(result.body, "sending is success in AuthorizationResponseTests")
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertEqual(recordedRequest.requestBody?["state"] as? String, state)
         let presentationSubmission: String? = recordedRequest.requestBody?["presentation_submission"]

--- a/Tests/OpenID4VPTests/Common/UtilsTest.swift
+++ b/Tests/OpenID4VPTests/Common/UtilsTest.swift
@@ -212,4 +212,47 @@ class UtilsTest : XCTestCase {
             XCTAssertTrue(error is UnsupportedOperationException)
         }
     }
+    
+    // MARK: - resolveJwksFromUri Tests
+    
+    let mockNetworkManager = MockNetworkManager()
+    let jwksUri = "https://example.com/jwks"
+    
+    func testResolveJwksFromUriSuccess() async throws {
+        let validJwksJson = """
+        {"keys":[{"kty":"RSA","kid":"1","n":"abc","e":"AQAB"}]}
+        """
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: validJwksJson)
+        
+        let jwks = try await resolveJwksFromUri(jwksUri, networkManager: mockNetworkManager, className: testClassName)
+        
+        XCTAssertEqual(jwks.keys.count, 1)
+        XCTAssertEqual(jwks.keys[0].keyType, .rsa)
+        XCTAssertEqual(jwks.keys[0].keyID, "1")
+    }
+    
+    func testResolveJwksFromUriNon200StatusCode() async {
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: "Not found", statusCode: 404)
+        
+        await XCTAssertAsyncThrowsError(try await resolveJwksFromUri(self.jwksUri, networkManager: self.mockNetworkManager, className: self.testClassName)) { error in
+            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Unable to fetch/parse jwks from https://example.com/jwks due to Error while fetching jwks information, status code: 404 with body: Not found", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+        }
+    }
+    
+    func testResolveJwksFromUriInvalidJwksParsing() async {
+        let invalidJwksJson = "{not a jwks}" // invalid JSON
+        mockNetworkManager.setMockResponse(for: jwksUri, responseBody: invalidJwksJson)
+        
+        await XCTAssertAsyncThrowsError(try await resolveJwksFromUri(self.jwksUri, networkManager: self.mockNetworkManager, className: self.testClassName)) { error in
+            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Unable to fetch/parse jwks from https://example.com/jwks due to The data couldn’t be read because it isn’t in the correct format.", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+        }
+    }
+    
+    func testResolveJwksFromUriNetworkError() async {
+        mockNetworkManager.setMockResponse(for: jwksUri, error: NetworkRequestException.networkRequestFailed(message: "Simulated network error"))
+        
+        await XCTAssertAsyncThrowsError(try await resolveJwksFromUri(self.jwksUri, networkManager: self.mockNetworkManager, className: self.testClassName)) { error in
+            assertOpenID4VPException(error, expectedMessage: "Public key extraction failed - Unable to fetch/parse jwks from https://example.com/jwks due to Network request failed with error response - Simulated network error", expectedCode: OpenID4VPErrorCodes.invalidRequestObject)
+        }
+    }
 }

--- a/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
+++ b/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
@@ -14,6 +14,7 @@ class MockNetworkManager: NetworkManaging {
         for urlString: String,
         response: (responseBody: String, httpUrlResponse: HTTPURLResponse?)? = nil,
         responseBody: String? = nil,
+        statusCode: Int? = nil,
         error: Error? = nil
     ) {
         guard let url = URL(string: urlString) else {
@@ -23,7 +24,7 @@ class MockNetworkManager: NetworkManaging {
 
         let defaultHttpUrlResponse = HTTPURLResponse(
             url: url,
-            statusCode: 200,
+            statusCode: statusCode ?? 200,
             httpVersion: "",
             headerFields: ["Content-Type": "application/json"]
         )!

--- a/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
+++ b/Tests/OpenID4VPTests/NetworkManager/NetworkManager.swift
@@ -76,13 +76,13 @@ class MockNetworkManager: NetworkManaging {
             return NetworkResponse(
                 statusCode: resp.httpUrlResponse.statusCode,
                 body: resp.responseBody,
-                headers: resp.httpUrlResponse
+                headers: resp.httpUrlResponse.headers.dictionary
             )
         }
         return NetworkResponse(
             statusCode: defaultHttpUrlResponse.statusCode,
             body: "Success: Request completed successfully.",
-            headers: defaultHttpUrlResponse
+            headers: defaultHttpUrlResponse.headers.dictionary
         )
     }
 }

--- a/Tests/OpenID4VPTests/NetworkManager/NetworkManagerTests.swift
+++ b/Tests/OpenID4VPTests/NetworkManager/NetworkManagerTests.swift
@@ -22,4 +22,9 @@ final class NetworkManagerTests: XCTestCase {
         }
     }
     
+    func testReturnFalseForNon2xxStatusCode() async throws {
+        let response = NetworkResponse(statusCode: 400, body: "", headers: [:])
+        
+        XCTAssertFalse(response.isOK)
+    }
 }

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -532,7 +532,9 @@ class OpenID4VPTests: XCTestCase {
         openID4VP.setResponseUri("https://mock-verifier.com")
         
         await XCTAssertNoThrowAndVerifyAsync(try await openID4VP.sendErrorResponseToVerifier(error: error)) { result in
-            XCTAssertEqual(result, "Success: Request completed successfully.")
+            XCTAssertEqual(result.body, "Success: Request completed successfully.")
+            XCTAssertEqual(result.statusCode, 200)
+            XCTAssertEqual(result.headers, ["Content-Type": "text/json"])
         }
     }
     
@@ -553,7 +555,7 @@ class OpenID4VPTests: XCTestCase {
                 error,
                 expectedMessage: "Missing Input: presentation_definition->id param is required",
                 expectedCode: OpenID4VPErrorCodes.invalidRequest,
-                expectedVerifierResponse: "Success: Request completed successfully."
+                expectedVerifierResponse: NetworkResponse(statusCode: 200, body: "Success: Request completed successfully.", headers: ["Content-Type": "text/json"])
             )
         }
     }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -302,7 +302,7 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
         do {
             let result = try await directPostJwtResponseModeHandler.sendAuthorizationResponse(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostJwtResponseMode, authorizationResponse: authorizationResponse, url: mockAuthorizationRequestObjectWithDirectPostJwtResponseMode.responseUri!, networkManager: mockNetworkManager,
                                                                                               producerInfo: "mock-nonce",
-                                                                                              recepientInfo: "verifier-nonce"
+                                                                                              recipientInfo: "verifier-nonce"
             )
             
             let recordedRequest = mockNetworkManager.recordedRequests[responseUri]

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -310,7 +310,7 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
             XCTAssertTrue(recordedRequest?.requestBody?.keys.count == 1)
             XCTAssertTrue(((recordedRequest?.requestBody?.keys.allSatisfy(["request"].contains(_:))) != nil))
             assertDictionariesEqual(expected: ["Content-Type":ContentTypes.applicationFormUrlEncoded.rawValue], actual: recordedRequest?.requestHeaders)
-            XCTAssertEqual("Response has been shared successfully here.", result)
+            XCTAssertEqual("Response has been shared successfully here.", result.body)
         }
     }
 }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -37,7 +37,7 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
             XCTAssertTrue(recordedRequest?.requestBody?.keys.count == 3)
             XCTAssertTrue((recordedRequest?.requestBody?.keys.allSatisfy(["vp_token", "presentation_submission", "state"].contains(_:))) != nil)
             assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: recordedRequest?.requestHeaders)
-            XCTAssertEqual("Response has been shared successfully here.", result)
+            XCTAssertEqual("Response has been shared successfully here.", result.body)
         }
     }
 

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -30,7 +30,7 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
         do {
             let result = try await directPostAuthorizationResponseModeHandler.sendAuthorizationResponse(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode, authorizationResponse: authorizationResponse, url: mockAuthorizationRequestObjectWithDirectPostResponseMode.responseUri!, networkManager: mockNetworkManager,
                                                                                                         producerInfo: "mock-nonce",
-                                                                                                        recepientInfo: "verifier-nonce")
+                                                                                                        recipientInfo: "verifier-nonce")
 
             let recordedRequest = mockNetworkManager.recordedRequests[responseUri]
             XCTAssertEqual(HttpMethod.post, recordedRequest?.requestMethod)

--- a/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
+++ b/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
@@ -211,9 +211,9 @@ func assertOpenID4VPException(
     XCTAssertEqual(expectedMessage, ex.message, file: file, line: line)
     XCTAssertEqual(expectedCode, ex.errorCode, file: file, line: line)
     if(expectedVerifierResponse != nil) {
-        XCTAssertEqual(expectedVerifierResponse?.body, (error as? OpenID4VPException)?.networkResponse?.body)
-        XCTAssertEqual(expectedVerifierResponse?.headers, (error as? OpenID4VPException)?.networkResponse?.headers)
-        XCTAssertEqual(expectedVerifierResponse?.statusCode, (error as? OpenID4VPException)?.networkResponse?.statusCode)
+        XCTAssertEqual(expectedVerifierResponse?.body, (error as? OpenID4VPException)?.networkResponse?.body, file: file, line: line)
+        XCTAssertEqual(expectedVerifierResponse?.headers, (error as? OpenID4VPException)?.networkResponse?.headers, file: file, line: line)
+        XCTAssertEqual(expectedVerifierResponse?.statusCode, (error as? OpenID4VPException)?.networkResponse?.statusCode, file: file, line: line)
     }
 }
 

--- a/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
+++ b/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
@@ -200,7 +200,7 @@ func assertOpenID4VPException(
     _ error: Error,
     expectedMessage: String,
     expectedCode: String,
-    expectedVerifierResponse: String? = nil,
+    expectedVerifierResponse: NetworkResponse? = nil,
     file: StaticString = #file,
     line: UInt = #line
 ) {
@@ -211,7 +211,9 @@ func assertOpenID4VPException(
     XCTAssertEqual(expectedMessage, ex.message, file: file, line: line)
     XCTAssertEqual(expectedCode, ex.errorCode, file: file, line: line)
     if(expectedVerifierResponse != nil) {
-        XCTAssertEqual(expectedVerifierResponse, (error as? OpenID4VPException)?.response)
+        XCTAssertEqual(expectedVerifierResponse?.body, (error as? OpenID4VPException)?.networkResponse?.body)
+        XCTAssertEqual(expectedVerifierResponse?.headers, (error as? OpenID4VPException)?.networkResponse?.headers)
+        XCTAssertEqual(expectedVerifierResponse?.statusCode, (error as? OpenID4VPException)?.networkResponse?.statusCode)
     }
 }
 

--- a/Tests/OpenID4VPTests/jwt/KeyResolver/types/did/types/DidWebResolverTests.swift
+++ b/Tests/OpenID4VPTests/jwt/KeyResolver/types/did/types/DidWebResolverTests.swift
@@ -196,6 +196,21 @@ final class DidWebResolverTests: XCTestCase {
         }
     }
     
+    func testThrowsErrorWhenDidResponseHasNon200StatusCode() async throws {
+        let didDocJSON = "{\"message\": \"something went wrong\"}"
+        mockNetworkManager.setMockResponse(
+            for: "https://example.com/.well-known/did.json",
+            responseBody: didDocJSON,
+            statusCode: 400
+        )
+        
+        let resolver = DidWebResolver(networkManager: mockNetworkManager)
+        
+        await XCTAssertAsyncThrowsError(try await resolver.extractPublicKey(parsedDID:parsedDid, keyId: "did:web:example.com#key1")) { error in
+            assertOpenID4VPException(error, expectedMessage: "Error while resolving did, status code: 400 with body: {\"message\": \"something went wrong\"}", expectedCode: "invalid_request")
+        }
+    }
+    
     func testThrowsErrorWhenDidResponseIsNotValidJson() async throws {
         let didDocJSON = """
             [{


### PR DESCRIPTION
- shareVerifiablePresentation method is depreacated now
- use sendAuthorizationResponseToVerifier instead Reason: shareVerifiablePresentation returns only the verifier response's response body so new method i s introduced to send the entire verifier response as network response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Responses now include full network details (status code, headers, body) via a NetworkResponse object; isOK helper added.

- Documentation
  - README updated with the new API names, usage examples, and deprecation notes.

- Breaking Changes
  - Multiple public APIs now return NetworkResponse instead of plain strings; callers must use the response body, status, and headers.

- Deprecations
  - Old shareVerifiablePresentation retained as deprecated wrapper returning body only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->