### PR TITLE
[INJIMOB-3534] add: share error on unsupported - transaction data

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
@@ -146,6 +146,9 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerBaseClass  {
     }
     
     func validateAndParseRequestFields() async throws {
+        if authorizationRequestParameters[AuthorizationRequestFieldConstants.transactionData.rawValue] != nil {
+            throw InvalidRequest(message: "Invalid Request: transaction_data is not supported in the authorization request", className: className)
+        }
         let mandatoryFields = [AuthorizationRequestFieldConstants.responseType.rawValue,AuthorizationRequestFieldConstants.nonce.rawValue]
         
         for field in mandatoryFields {

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestHandler.swift
@@ -147,7 +147,7 @@ class ClientIdSchemeBasedAuthorizationRequestHandlerBaseClass  {
     
     func validateAndParseRequestFields() async throws {
         if authorizationRequestParameters[AuthorizationRequestFieldConstants.transactionData.rawValue] != nil {
-            throw InvalidRequest(message: "Invalid Request: transaction_data is not supported in the authorization request", className: className)
+            throw InvalidTransactionData(message: "Invalid Request: transaction_data is not supported in the authorization request", className: className)
         }
         let mandatoryFields = [AuthorizationRequestFieldConstants.responseType.rawValue,AuthorizationRequestFieldConstants.nonce.rawValue]
         

--- a/Sources/OpenID4VP/Constants/AuthorizationRequestFieldConstants.swift
+++ b/Sources/OpenID4VP/Constants/AuthorizationRequestFieldConstants.swift
@@ -13,4 +13,5 @@ public enum AuthorizationRequestFieldConstants: String {
     case state = "state"
     case clientMetadata = "client_metadata"
     case walletNonce = "wallet_nonce"
+    case transactionData = "transaction_data"
 }

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -332,6 +332,12 @@ public class InvalidTransactionData: OpenID4VPException {
     }
 }
 
+class InvalidRequest: OpenID4VPException {
+    init(message: String, className: String) {
+        super.init(errorCode: OpenID4VPErrorCodes.invalidRequest, message: message, className: className)
+    }
+}
+
 public class UnsupportedOperationException : OpenID4VPException {
     public init(message: String, className: String, code: String = "unsupported_operation") {
         super.init(errorCode: code, message: message, className: className)

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -332,12 +332,6 @@ public class InvalidTransactionData: OpenID4VPException {
     }
 }
 
-class InvalidRequest: OpenID4VPException {
-    init(message: String, className: String) {
-        super.init(errorCode: OpenID4VPErrorCodes.invalidRequest, message: message, className: className)
-    }
-}
-
 public class UnsupportedOperationException : OpenID4VPException {
     public init(message: String, className: String, code: String = "unsupported_operation") {
         super.init(errorCode: code, message: message, className: className)

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
@@ -807,4 +807,21 @@ class ClientIdSchemeBasedAuthorizationRequestTests : XCTestCase {
             )
         }
     }
+    
+    func testShouldThrowErrorWhenTransactionDataIsPresentInAuthorizationRequest() async {
+        let authorizationRequestParameters: [String: Any] = mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdDraft23, [AuthorizationRequestFieldConstants.transactionData.rawValue: ["foo": "bar"]])
+        let mockAuthHandler = MockClientIdSchemeAuthRequestHandler(
+            authorizationRequestParameters: authorizationRequestParameters,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        await XCTAssertAsyncThrowsError(try await mockAuthHandler.validateAndParseRequestFields()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Invalid Request: transaction_data is not supported in the authorization request",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdSchemeBasedAuthorizationRequestTests.swift
@@ -820,7 +820,7 @@ class ClientIdSchemeBasedAuthorizationRequestTests : XCTestCase {
             assertOpenID4VPException(
                 error,
                 expectedMessage: "Invalid Request: transaction_data is not supported in the authorization request",
-                expectedCode: OpenID4VPErrorCodes.invalidRequest
+                expectedCode: OpenID4VPErrorCodes.invalidTransactionData
             )
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Authorization requests containing unsupported transaction_data are now rejected with a clear error and specific code, improving validation and reliability.
  - Clearer error messaging: “Invalid Request: transaction_data is not supported in the authorization request.”

- Tests
  - Added unit test to verify that requests with transaction_data are correctly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->