### PR TITLE
[INJIMOB-3626] refactor: modify sendAuthorizationResponseToVerifier, sendErrorResponseToVerifier signature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ inji-openid4vp-ios-swift is an implementation of OpenID for Verifiable Presentat
 - [APIs](#apis)
   - [authenticateVerifier](#authenticateverifier)
   - [constructUnsignedVPToken](#constructUnsignedVPToken)
-  - [sendAuthorizationResponseToVerifier](#sendauthorizationresponsetoverifier)
-  - [sendErrorResponseToVerifier](#senderrorresponsetoverifier)
+  - [sendVPResponseToVerifier](#sendvpresponsetoverifier)
+  - [sendErrorInfoToVerifier](#senderrorinfotoverifier)
 
 ## OpenID4VP specification draft versions supported
 
@@ -22,18 +22,18 @@ inji-openid4vp-ios-swift is an implementation of OpenID for Verifiable Presentat
 
 ## Supported features
 
-| Feature                                                    | Supported values                                                                                                                                                                                                                                                                                                                                 |
-|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Device flow                                                | Cross device flow, Same device flow (only `direct_post` and `direct_post.jwt` supported)                                                                                                                                                                                                                                                         |
-| Client id scheme                                           | `pre-registered`, `redirect_uri`, `did`                                                                                                                                                                                                                                                                                                          |
-| Signed authorization request verification algorithms       | Ed25519                                                                                                                                                                                                                                                                                                                                          |
-| Obtaining authorization request                            | - By value : both signed (via `request` param) and unsigned (via URL encoded parameters)<br/> - By reference ( via `request_uri` method)<br/>_Note: The use of signed or unsigned requests, is determined by the `client_id_scheme` associated with the client._ ([more details](#client-id-schemes-and-signed-unsigned-request-support-matrix)) |
-| Obtaining presentation definition in authorization request | By value, By reference (via `presentation_definition_uri`)                                                                                                                                                                                                                                                                                       |
-| Authorization Response content encryption algorithms       | `A256GCM`                                                                                                                                                                                                                                                                                                                                        |
-| Authorization Response key encryption algorithms           | `ECDH-ES`                                                                                                                                                                                                                                                                                                                                        |
-| Credential formats                                         | `ldp_vc`, `mso_mdoc`, `dc+sd-jwt`, `vc+sd-jwt`                                                                                                                                                                                                                                                                                                   |
-| Authorization Response mode                                | `direct_post`, `direct_post.jwt` (with encrypted & unsigned responses)                                                                                                                                                                                                                                                                           |
-| Authorization Response type                                | `vp_token`                                                                                                                                                                                                                                                                                                                                       |
+| Feature                                                    | Supported values                                                                                                                                                                                                                                                                                                                                  |
+|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Device flow                                                | Cross device flow, Same device flow (only `direct_post` and `direct_post.jwt` supported)                                                                                                                                                                                                                                                          |
+| Client id scheme                                           | `pre-registered`, `redirect_uri`, `did`                                                                                                                                                                                                                                                                                                           |
+| Signed authorization request verification algorithms       | Ed25519                                                                                                                                                                                                                                                                                                                                           |
+| Obtaining authorization request                            | - By value : both signed (via `request` param) and unsigned (via URL encoded parameters)<br/> - By reference ( via `request_uri` method)<br/>_Note: The use of signed or unsigned requests, is determined by the `client_id_scheme` associated with the client._ ([more details](#client-id-schemes-and-signed--unsigned-request-support-matrix)) |
+| Obtaining presentation definition in authorization request | By value, By reference (via `presentation_definition_uri`)                                                                                                                                                                                                                                                                                        |
+| Authorization Response content encryption algorithms       | `A256GCM`                                                                                                                                                                                                                                                                                                                                         |
+| Authorization Response key encryption algorithms           | `ECDH-ES`                                                                                                                                                                                                                                                                                                                                         |
+| Credential formats                                         | `ldp_vc`, `mso_mdoc`, `dc+sd-jwt`, `vc+sd-jwt`                                                                                                                                                                                                                                                                                                    |
+| Authorization Response mode                                | `direct_post`, `direct_post.jwt` (with encrypted & unsigned responses)                                                                                                                                                                                                                                                                            |
+| Authorization Response type                                | `vp_token`                                                                                                                                                                                                                                                                                                                                        |
 
 ### Client ID Schemes and Signed / Unsigned request support matrix
 
@@ -354,12 +354,12 @@ let unsignedVPTokens: [FormatType: UnsignedVPToken] = try openID4VP.constructUns
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
-### sendAuthorizationResponseToVerifier
+### sendVPResponseToVerifier
 - This function constructs a vp_token with proof using received VPTokenSigningResult, then sends it and the presentation_submission to the Verifier via a HTTP POST request.
-- Returns the response back to the consumer app(mobile app) saying whether it has received the shared Verifiable Credentials or not.
+- Returns back the response received from the Verifier. Refer here for the structure of VerifierResponse - [VerifierResponse structure](#verifierresponse-structure)
 
 ```swift
-    let response = try await openID4VP.sendAuthorizationResponseToVerifier(vpTokenSigningResults: [FormatType:VPTokenSigningResult])
+    let response = try await openID4VP.sendVPResponseToVerifier(vpTokenSigningResults: [FormatType:VPTokenSigningResult])
 ```
 
 ###### Parameters
@@ -368,6 +368,18 @@ This method will also notify the Verifier about the error by sending it to the r
 |-----------------------|------------------------------------|:---------|:--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | vpTokenSigningResults | [FormatType: VPTokenSigningResult] | Yes      | N/A           | This will be a map with key as credential format and value as VPTokenSigningResult (which is specific to respective credential format's required information) |
 
+### Response Parameters
+
+VerifierResponse contains the following properties:
+
+#### VerifierResponse structure
+
+| Name             | Type             | Description                                                                                                   |
+|------------------|------------------|---------------------------------------------------------------------------------------------------------------|
+| statusCode       | Int              | HTTP status code received from the Verifier                                                                   |
+| redirectUri      | String           | The redirect URI to which the wallet application needs to redirect after sending the response to the Verifier |     
+| additionalParams | Map<String, Any> | A map containing any additional response body parameters received from the Verifier                           |
+| headers          | Map<String, Any> | A map containing any headers received from the Verifier                                                       |
 
 ###### Example usage
 
@@ -388,7 +400,7 @@ let mdocVPTokenSigningResult = MdocVPTokenSigningResult(
     ]
   )
 let vpTokenSigningResults : [FormatType: VPTokenSigningResult] = [FormatType.ldp_vc : ldpVPTokenSigningResult, FormatType.mso_mdoc: mdocVPTokenSigningResult]
-let response : NetworkResponse = try await openID4VP.sendAuthorizationResponseToVerifier(vpTokenSigningResults : vpTokenSigningResults)
+let response : VerifierResponse = try await openID4VP.sendVPResponseToVerifier(vpTokenSigningResults : vpTokenSigningResults)
 ```
 
 ###### Exceptions
@@ -402,7 +414,7 @@ let response : NetworkResponse = try await openID4VP.sendAuthorizationResponseTo
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
-### shareVerifiablePresentation (deprecated, use sendAuthorizationResponseToVerifier instead)
+### shareVerifiablePresentation (deprecated, use sendVPResponseToVerifier instead)
 - This function constructs a vp_token with proof using received VPTokenSigningResult, then sends it and the presentation_submission to the Verifier via a HTTP POST request.
 - Returns the response back to the consumer app(mobile app) saying whether it has received the shared Verifiable Credentials or not.
 
@@ -450,16 +462,16 @@ val response : String = try await openID4VP.shareVerifiablePresentation(vpTokenS
 
 This method will also notify the Verifier about the error by sending it to the response_uri endpoint over http post request. If response_uri is invalid and validation failed then Verifier won't be able to know about it.
 
-### sendErrorResponseToVerifier
+### sendErrorInfoToVerifier
 
 - Receives an exception and sends it's message to the Verifier via an HTTP POST request to the Verifier's response_uri endpoint.
-- Returns back the response body received from the Verifier.
+- Returns back the response received from the Verifier. Refer here for the structure of VerifierResponse - [VerifierResponse structure](#verifierresponse-structure)
 
 ```swift
 // Example: The user declines to share the requested credentials. In this case, Verifier needs to be informed about the scenario.
-// So call the sendErrorResponseToVerifier method with appropriate exception message to notify the Verifier.
+// So call the sendErrorInfoToVerifier method with appropriate exception message to notify the Verifier.
 
-let verifierResponse: NetworkResponse = openID4VP.sendErrorResponseToVerifier(
+let verifierResponse: VerifierResponse = openID4VP.sendErrorInfoToVerifier(
         AccessDenied(
             message = "User did not give consent to share the requested Credentials with the Verifier.",
             className = this.className
@@ -470,7 +482,7 @@ let verifierResponse: NetworkResponse = openID4VP.sendErrorResponseToVerifier(
 
 1. ErrorDispatchFailure is thrown if any issue occurs while sending the Authorization Error response to the Verifier.
 
-### sendErrorToVerifier (deprecated, use sendErrorResponseToVerifier instead)
+### sendErrorToVerifier (deprecated, use sendErrorInfoToVerifier instead)
 - Receives an exception and sends it's message to the Verifier via a HTTP POST request.
 
 ```
@@ -505,7 +517,7 @@ This exception has the following properties:
 
 1. errorCode: A unique code representing the type of error.
 2. message: A descriptive message providing details about the error.
-3. networkResponse: An optional property that holds the Verifier response obtained while sending the error to Verifier.
+3. verifierResponse: An optional property that holds the Verifier response obtained while sending the error to Verifier. Refer here for the structure of VerifierResponse - [VerifierResponse structure](#verifierresponse-structure)
 4. className: The name of the class where the exception occurred.
 
 
@@ -513,10 +525,10 @@ This exception has the following properties:
 
 The following methods are deprecated and will be removed in future releases. Please migrate to the suggested alternatives.
 
-| Method Name                 | Description                                   | Deprecated Since | Suggested Alternative                                                       |
-|-----------------------------|-----------------------------------------------|------------------|-----------------------------------------------------------------------------|
-| shareVerifiablePresentation | Sends VP (Authorization response) to verifier | 0.6.0            | [sendAuthorizationResponseToVerifier](#sendauthorizationresponsetoverifier) |
-| sendErrorToVerifier         | Sends Authorization error to the verifier     | 0.6.0            | [sendErrorResponseToVerifier](#senderrorresponsetoverifier)                 |
+| Method Name                 | Description                                   | Deprecated Since | Suggested Alternative                                 |
+|-----------------------------|-----------------------------------------------|------------------|-------------------------------------------------------|
+| shareVerifiablePresentation | Sends VP (Authorization response) to verifier | 0.6.0            | [sendVPResponseToVerifier](#sendvpresponsetoverifier) |
+| sendErrorToVerifier         | Sends Authorization error to the verifier     | 0.6.0            | [sendErrorInfoToVerifier](#senderrorinfotoverifier)   |
 
 ## Architecture decisions
 

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -75,7 +75,7 @@ public class AuthorizationResponseHandler {
         return unsignedVPTokensExtracted
     }
     
-    func sendAuthorizationError(responseUri: String?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> NetworkResponse {
+    func sendAuthorizationError(responseUri: String?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> VerifierResponse {
         guard let responseUri = responseUri, !responseUri.isEmpty else {
             throw ErrorDispatchFailure(message: "Response URI is not set. Cannot send error to verifier.", className: Self.className)
         }        
@@ -107,8 +107,10 @@ public class AuthorizationResponseHandler {
                 bodyParams: errorPayload,
                 headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
             )
-            (error as? OpenID4VPException)?.setNetworkResponse(dispatchResult)
-            return dispatchResult
+            let verifierResponse: VerifierResponse = toVerifierResponse(dispatchResult)
+            
+            (error as? OpenID4VPException)?.setVerifierResponse(verifierResponse)
+            return verifierResponse
         } catch {
             throw ErrorDispatchFailure(
                 message: "Failed to send error to verifier: \(error)",
@@ -118,21 +120,22 @@ public class AuthorizationResponseHandler {
     }
     
     
-    public func shareVP(
+    func shareVP(
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: [FormatType: VPTokenSigningResult],
         responseUri: String
-    ) async throws -> NetworkResponse {
+    ) async throws -> VerifierResponse {
         let authorizationResponse = try createAuthorizationResponse(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults
         )
         
-        return try await sendAuthorizationResponse(
+        let response: NetworkResponse = try await sendAuthorizationResponse(
             authorizationRequest: authorizationRequest,
             authorizationResponse: authorizationResponse,
             responseUri: responseUri
         )
+        return toVerifierResponse(response)
     }
     
     private func createAuthorizationResponse(
@@ -486,5 +489,32 @@ public class AuthorizationResponseHandler {
             }
         }
         self.formatToCredentialInputDescriptorMapping = formatToCredentialInputDescriptorMapping
+    }
+    
+    private func toVerifierResponse(_ networkResponse: NetworkResponse) -> VerifierResponse {
+        let redirectUriKey = "redirect_uri"
+        
+        var redirectUri: String? = nil
+        var additionalParams: String? = networkResponse.body
+        
+        if let data = networkResponse.body.data(using: .utf8),
+           var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            
+            redirectUri = json[redirectUriKey] as? String
+            
+            json.removeValue(forKey: redirectUriKey)
+            if let cleanedData = try? JSONSerialization.data(withJSONObject: json, options: []),
+               let cleanedString = String(data: cleanedData, encoding: .utf8) {
+                additionalParams = cleanedString
+            }
+        }
+        
+        return VerifierResponse(
+            statusCode: networkResponse.statusCode,
+            responseBody: networkResponse.body,
+            redirectUri: redirectUri,
+            additionalParams: additionalParams,
+            headers: networkResponse.headers
+        )
     }
 }

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -5,10 +5,10 @@ public class OpenID4VPException: Error, CustomStringConvertible, LocalizedError 
     public let message: String
     public let className: String
     // holds the response received from the Verifier if the error is sent to the Verifier
-    public var networkResponse: NetworkResponse?
+    public var verifierResponse: VerifierResponse?
     
-    internal func setNetworkResponse(_ response: NetworkResponse) {
-        self.networkResponse = response
+    internal func setVerifierResponse(_ response: VerifierResponse) {
+        self.verifierResponse = response
     }
     
     private static var logTag = ""

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -83,9 +83,9 @@ public class OpenID4VP {
         }
     }
     
-    public func sendAuthorizationResponseToVerifier(
+    public func sendVPResponseToVerifier(
         vpTokenSigningResults: [FormatType: VPTokenSigningResult]
-    ) async throws -> NetworkResponse {
+    ) async throws -> VerifierResponse {
         do {
             return try await authorizationResponseHandler.shareVP(
                 authorizationRequest: authorizationRequest,
@@ -98,24 +98,24 @@ public class OpenID4VP {
         }
     }
     
-    public func sendErrorResponseToVerifier(error: Error) async throws -> NetworkResponse {
+    public func sendErrorInfoToVerifier(error: Error) async throws -> VerifierResponse {
        return try await authorizationResponseHandler.sendAuthorizationError(responseUri: self.responseUri, authorizationRequest: self.authorizationRequest, error: error)
     }
     
     private func safeSendError(error: Error) async {
         do {
-            let verifierResponse = try await sendErrorResponseToVerifier(error: error)
-            (error as? OpenID4VPException)?.setNetworkResponse(verifierResponse)
+            let verifierResponse = try await sendErrorInfoToVerifier(error: error)
+            (error as? OpenID4VPException)?.setVerifierResponse(verifierResponse)
         } catch {
             OpenID4VPException.error(error, className: className)
         }
     }
     
-    @available(*, deprecated, renamed: "sendAuthorizationResponseToVerifier", message: "This method does not support listening to the status code sent from the verifier. Replace with sendAuthorizationResponseToVerifier(vpTokenSigningResults)")
+    @available(*, deprecated, renamed: "sendVPResponseToVerifier", message: "This method does not support listening to the status code sent from the verifier. Replace with sendVPResponseToVerifier(vpTokenSigningResults)")
     public func shareVerifiablePresentation(
         vpTokenSigningResults: [FormatType: VPTokenSigningResult]
     ) async throws -> String {
-        return try await self.sendAuthorizationResponseToVerifier(vpTokenSigningResults: vpTokenSigningResults).body
+        return try await self.sendVPResponseToVerifier(vpTokenSigningResults: vpTokenSigningResults).body()
     }
     
     @available(*, deprecated, message: "Use authenticateVerifier without WalletMetadata instead. Reason: WalletMetadata is moved to OpenID4VP constructor instead of being passed as parameter")
@@ -178,7 +178,7 @@ public class OpenID4VP {
         }
     }
     
-    @available(*, deprecated, renamed: "sendErrorResponseToVerifier", message: "sendErrorToVerifier is now changed to sendErrorResponseToVerifier. Reason: This does not support listening the response from the verifier")
+    @available(*, deprecated, renamed: "sendErrorInfoToVerifier", message: "sendErrorToVerifier is now changed to sendErrorInfoToVerifier. Reason: This does not support listening the response from the verifier")
     public func sendErrorToVerifier(error: Error) async {
         await self.safeSendError(error: error)
     }

--- a/Sources/OpenID4VP/Verifier/VerifierResponse.swift
+++ b/Sources/OpenID4VP/Verifier/VerifierResponse.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct VerifierResponse : Codable {
+    let statusCode: Int
+    /// Holds redirect_uri from the Verifier response body
+    let redirectUri: String?
+    /// Holds additional parameters in JSON string format other than redirect_uri
+    let additionalParams: String?
+    let headers: [String: String]
+    private let responseBody: String
+    
+    init(statusCode: Int, responseBody: String = "", redirectUri: String? = nil, additionalParams: String? = nil, headers: [String: String]) {
+        self.statusCode = statusCode
+        self.responseBody = responseBody
+        self.redirectUri = redirectUri
+        self.additionalParams = additionalParams
+        self.headers = headers
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        statusCode = try container.decode(Int.self, forKey: .statusCode)
+        redirectUri = try container.decodeIfPresent(String.self, forKey: .redirectUri)
+        additionalParams = try container.decodeIfPresent(String.self, forKey: .additionalParams)
+        headers = try container.decode([String: String].self, forKey: .headers)
+        responseBody = ""
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case statusCode
+        case redirectUri
+        case additionalParams
+        case headers
+    }
+    
+    func isOk() -> Bool {
+        return (200...299).contains(statusCode)
+    }
+    
+    internal func body() -> String {
+        return responseBody
+    }
+}

--- a/Sources/OpenID4VP/Verifier/VerifierResponse.swift
+++ b/Sources/OpenID4VP/Verifier/VerifierResponse.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public struct VerifierResponse : Codable {
-    let statusCode: Int
+    public let statusCode: Int
     /// Holds redirect_uri from the Verifier response body
-    let redirectUri: String?
+    public let redirectUri: String?
     /// Holds additional parameters in JSON string format other than redirect_uri
-    let additionalParams: String?
-    let headers: [String: String]
+    public let additionalParams: String?
+    public let headers: [String: String]
     private let responseBody: String
     
     init(statusCode: Int, responseBody: String = "", redirectUri: String? = nil, additionalParams: String? = nil, headers: [String: String]) {
@@ -33,7 +33,7 @@ public struct VerifierResponse : Codable {
         case headers
     }
     
-    func isOk() -> Bool {
+    public func isOk() -> Bool {
         return (200...299).contains(statusCode)
     }
     

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -115,7 +115,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             responseUri: responseUri
         )
         
-        XCTAssertEqual(result.body, "sending is success in AuthorizationResponseTests")
+        XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertEqual(recordedRequest.requestBody?["state"] as? String, state)
         XCTAssertNotNil(recordedRequest.requestBody?["presentation_submission"])
@@ -153,7 +153,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             responseUri: responseUri
         )
         
-        XCTAssertEqual(result.body, "sending is success in AuthorizationResponseTests")
+        XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertEqual(recordedRequest.requestBody?.keys.count, 1)
         XCTAssertNotNil(recordedRequest.requestBody?["response"])
@@ -367,7 +367,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let result = try await handler.shareVP(authorizationRequest: authorizationRequest, vpTokenSigningResults: [.vc_sd_jwt: SdJwtVpTokenSigningResult(uuidToKbJWTSignature: [sdJwtUUID: "ayuht"])], responseUri: responseUri)
 
 
-        XCTAssertEqual(result.body, "sending is success in AuthorizationResponseTests")
+        XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!
         XCTAssertEqual(recordedRequest.requestBody?["state"] as? String, state)
         let presentationSubmission: String? = recordedRequest.requestBody?["presentation_submission"]

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -20,6 +20,8 @@ class OpenID4VPTests: XCTestCase {
 
     let decodedClientMetadata =
         "{\"name\":\"dummyClient\"}"
+    let processedSuccessfullyMessage = "{\"message\":\"Some additional info\"}"
+    let responseUri = "https://mock-verifier.com"
 
     override func setUp() {
         super.setUp()
@@ -353,7 +355,7 @@ class OpenID4VPTests: XCTestCase {
     func testSendVPSuccess() async throws {
         mockNetworkManager.setMockResponse(
             for: "https://mock-verifier.com",
-            responseBody: "Success: Request completed successfully."
+            responseBody: "{\"message\":\"Some additional info\"}"
         )
 
         _ = try await openID4VP.authenticateVerifier(
@@ -377,7 +379,7 @@ class OpenID4VPTests: XCTestCase {
 
         let response = try await openID4VP.shareVerifiablePresentation(vpTokenSigningResults: vpTokenSigningResults)
 
-        XCTAssertEqual(response, "Success: Request completed successfully.")
+        XCTAssertEqual(response, "{\"message\":\"Some additional info\"}")
     }
 
 
@@ -405,7 +407,7 @@ class OpenID4VPTests: XCTestCase {
     }
 
     func testShareVPSuccessWhenResponseModeIsDirectPostJwt() async throws {
-        mockNetworkManager.setMockResponse(for: "https://mock-verifier.com", responseBody: "Success: Request completed successfully.")
+        mockNetworkManager.setMockResponse(for: "https://mock-verifier.com", responseBody: "{\"message\":\"Some additional info\"}")
 
         authorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: mockUrlEncodedVPRequestWithDirectPostJwt, trustedVerifierJSON: preRegisteredVerifiers, shouldValidateClient: true)
         _ = try! await openID4VP.constructUnsignedVPToken(verifiableCredentials: verifiableCredentialsList, holderId: "wallet-holder-id", signatureSuite: "JsonWebSignature2020")
@@ -413,7 +415,7 @@ class OpenID4VPTests: XCTestCase {
 
         let response = try await openID4VP.shareVerifiablePresentation(vpTokenSigningResults: vpTokenSigningResults)
 
-        XCTAssertEqual(response, "Success: Request completed successfully.")
+        XCTAssertEqual(response, "{\"message\":\"Some additional info\"}")
     }
 
     func testSendErrorToVerifier_withoutState() async {
@@ -505,28 +507,29 @@ class OpenID4VPTests: XCTestCase {
         XCTAssertTrue(mockNetworkManager.recordedRequests.count == 2, "No requests should be recorded as responseUri is nil" )
     }
     
-    func testThrowErrorWhenResponseUriNotAvailableDuringSendErrorResponseToVerifier
+    func testThrowErrorWhenResponseUriNotAvailableDuringsendErrorInfoToVerifier
     () async throws {
         let error = AccessDenied(message: "Some error", className: "test")
         let openID4VP = OpenID4VP(traceabilityId: "trace-id", networkManager: mockNetworkManager)
         
-        // directly call sendErrorResponseToVerifier
-        await XCTAssertAsyncThrowsError(try await openID4VP.sendErrorResponseToVerifier(error: error)) { error in
+        // directly call sendErrorInfoToVerifier
+        await XCTAssertAsyncThrowsError(try await openID4VP.sendErrorInfoToVerifier(error: error)) { error in
             XCTAssertEqual(error.localizedDescription, "Failed to send error to verifier: Response URI is not set. Cannot send error to verifier.", "error_dispatch_failure")
         }
     }
     
-    func testSuccessWhenSendErrorResponseToVerifierCalled
+    func testSuccessWhensendErrorInfoToVerifierCalled
     () async throws {
         let error = AccessDenied(message: "Some error", className: "test")
+        mockNetworkManager.setMockResponse(for: responseUri,responseBody: processedSuccessfullyMessage)
         
         let openID4VP = OpenID4VP(traceabilityId: "trace-id", networkManager: mockNetworkManager)
-        openID4VP.setResponseUri("https://mock-verifier.com")
+        openID4VP.setResponseUri(responseUri)
         
-        await XCTAssertNoThrowAndVerifyAsync(try await openID4VP.sendErrorResponseToVerifier(error: error)) { result in
-            XCTAssertEqual(result.body, "Success: Request completed successfully.")
+        await XCTAssertNoThrowAndVerifyAsync(try await openID4VP.sendErrorInfoToVerifier(error: error)) { result in
+            XCTAssertEqual(result.body(), "{\"message\":\"Some additional info\"}")
             XCTAssertEqual(result.statusCode, 200)
-            XCTAssertEqual(result.headers, ["Content-Type": "text/json"])
+            XCTAssertEqual(result.headers, ["Content-Type": "application/json"])
         }
     }
     
@@ -535,19 +538,21 @@ class OpenID4VPTests: XCTestCase {
         let error = AccessDenied(message: "Some error", className: "test")
         let openID4VP = OpenID4VP(traceabilityId: "trace-id", networkManager: mockNetworkManager)
         
-        // directly call sendErrorResponseToVerifier
+        // directly call sendErrorInfoToVerifier
         await XCTAssertNoThrowAndVerifyAsync(try await openID4VP.sendErrorToVerifier(error: error)) {
             print("No error thrown even when responseUri is not set")
         }
     }
     
     func testThrownExceptionHavingVerifierResponse() async {
+        mockNetworkManager.setMockResponse(for: responseUri,responseBody: "{\"message\":\"Some additional info\",\"redirect_uri\":\"https://mock-verifier.com/redirect#response_code=200\"}")
+        
         await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInvalidPresentationDefinitionVPRequest, trustedVerifierJSON: preRegisteredVerifiers, shouldValidateClient: true)) { error in
             assertOpenID4VPException(
                 error,
                 expectedMessage: "Missing Input: presentation_definition->id param is required",
                 expectedCode: OpenID4VPErrorCodes.invalidRequest,
-                expectedVerifierResponse: NetworkResponse(statusCode: 200, body: "Success: Request completed successfully.", headers: ["Content-Type": "text/json"])
+                expectedVerifierResponse: VerifierResponse(statusCode: 200, responseBody: "{\"message\":\"Some additional info\",\"redirect_uri\":\"https://mock-verifier.com/redirect#response_code=200\"}", redirectUri: "https://mock-verifier.com/redirect#response_code=200", additionalParams: "{\"message\":\"Some additional info\"}", headers: ["Content-Type": "application/json"])
             )
         }
     }

--- a/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
+++ b/Tests/OpenID4VPTests/TestHelpers/TestAssertions.swift
@@ -200,7 +200,7 @@ func assertOpenID4VPException(
     _ error: Error,
     expectedMessage: String,
     expectedCode: String,
-    expectedVerifierResponse: NetworkResponse? = nil,
+    expectedVerifierResponse: VerifierResponse? = nil,
     file: StaticString = #file,
     line: UInt = #line
 ) {
@@ -211,9 +211,12 @@ func assertOpenID4VPException(
     XCTAssertEqual(expectedMessage, ex.message, file: file, line: line)
     XCTAssertEqual(expectedCode, ex.errorCode, file: file, line: line)
     if(expectedVerifierResponse != nil) {
-        XCTAssertEqual(expectedVerifierResponse?.body, (error as? OpenID4VPException)?.networkResponse?.body, file: file, line: line)
-        XCTAssertEqual(expectedVerifierResponse?.headers, (error as? OpenID4VPException)?.networkResponse?.headers, file: file, line: line)
-        XCTAssertEqual(expectedVerifierResponse?.statusCode, (error as? OpenID4VPException)?.networkResponse?.statusCode, file: file, line: line)
+        let actualVerifierReponse = (error as? OpenID4VPException)?.verifierResponse
+        XCTAssertEqual(expectedVerifierResponse?.body(), actualVerifierReponse?.body(), file: file, line: line)
+        XCTAssertEqual(expectedVerifierResponse?.headers, actualVerifierReponse?.headers, file: file, line: line)
+        XCTAssertEqual(expectedVerifierResponse?.statusCode, actualVerifierReponse?.statusCode, file: file, line: line)
+        XCTAssertEqual(expectedVerifierResponse?.redirectUri, actualVerifierReponse?.redirectUri, file: file, line: line)
+        XCTAssertEqual(expectedVerifierResponse?.additionalParams, actualVerifierReponse?.additionalParams, file: file, line: line)
     }
 }
 


### PR DESCRIPTION
[INJIMOB-3626] refactor: modify sendAuthorizationResponseToVerifier, sendErrorResponseToVerifier name

Changes include
    1. sendAuthorizationResponseToVerifier renamed to sendVPResponseToVerifier
    2. sendErrorResponseToVerifier renamed to sendErrorInfoToVerifier


[INJIMOB-3626]: https://mosip.atlassian.net/browse/INJIMOB-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VerifierResponse type for improved handling of verifier responses.

* **Deprecated**
  * `sendAuthorizationResponseToVerifier` → use `sendVPResponseToVerifier`.
  * `sendErrorResponseToVerifier` → use `sendErrorInfoToVerifier`.
  * `shareVerifiablePresentation` deprecated; use `sendVPResponseToVerifier` instead.

* **Documentation**
  * Updated API documentation and code examples with new method names and response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->