### PR TITLE
[INJIVER-1628] fix: domain of ldp_vp proof to hold clientId

### DIFF
--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/LdpVP/UnsignedLdpVPTokenBuilder.swift
@@ -48,8 +48,9 @@ public class UnsignedLdpVPTokenBuilder: UnsignedVPTokenBuilder {
             type: signatureSuite,
             created: nil,
             challenge: challenge,
-            domain: holder,
-            verificationMethod: holder, proofValue: nil
+            domain: domain,
+            verificationMethod: holder,
+            proofValue: nil
         )
         
         let vpTokenSigningPayload = LdpVPToken(

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedLdpVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedLdpVPTokenBuilderTests.swift
@@ -33,7 +33,7 @@ final class UnsignedLdpVPTokenBuilderTests: XCTestCase {
         XCTAssertEqual(token.id, "ebc6f1c2")
         XCTAssertEqual(token.holder, "did:example:wallet")
         XCTAssertEqual(token.verifiableCredential.count, 1)
-        assertJsonString(expected: "{\"holder\":\"did:example:wallet\",\"type\":[\"VerifiablePresentation\"],\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\",\"https:\\/\\/w3id.org\\/security\\/suites\\/ed25519-2020\\/v1\"],\"id\":\"ebc6f1c2\",\"verifiableCredential\":[{\"type\":[\"VerifiableCredential\"],\"issuanceDate\":\"2020-08-19T21:41:50Z\",\"credentialSubject\":{\"id\":\"did:example:subject\"},\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\"],\"issuer\":\"did:example:issuer\"}],\"proof\":{\"verificationMethod\":\"did:example:wallet\",\"challenge\":\"test-challenge\",\"domain\":\"did:example:wallet\",\"type\":\"Ed25519Signature2020\"}}", actual: (unsignedVPToken as! UnsignedLdpVPToken).dataToSign)
+        assertJsonString(expected: "{\"holder\":\"did:example:wallet\",\"type\":[\"VerifiablePresentation\"],\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\",\"https:\\/\\/w3id.org\\/security\\/suites\\/ed25519-2020\\/v1\"],\"id\":\"ebc6f1c2\",\"verifiableCredential\":[{\"type\":[\"VerifiableCredential\"],\"issuanceDate\":\"2020-08-19T21:41:50Z\",\"credentialSubject\":{\"id\":\"did:example:subject\"},\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\"],\"issuer\":\"did:example:issuer\"}],\"proof\":{\"verificationMethod\":\"did:example:wallet\",\"challenge\":\"test-challenge\",\"domain\":\"test-domain\",\"type\":\"Ed25519Signature2020\"}}", actual: (unsignedVPToken as! UnsignedLdpVPToken).dataToSign)
     }
 
     func testCreationOfUnsignedLdpVPTokenWithDifferentSignatureSuite() async throws {
@@ -66,7 +66,7 @@ final class UnsignedLdpVPTokenBuilderTests: XCTestCase {
         XCTAssertEqual(token.id, "ebc6f1c2")
         XCTAssertEqual(token.holder, "did:example:wallet")
         XCTAssertEqual(token.verifiableCredential.count, 1)
-        assertJsonString(expected: "{\"holder\":\"did:example:wallet\",\"type\":[\"VerifiablePresentation\"],\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\",\"https:\\/\\/w3id.org\\/security\\/suites\\/jws-2020\\/v1\"],\"id\":\"ebc6f1c2\",\"verifiableCredential\":[{\"type\":[\"VerifiableCredential\"],\"issuanceDate\":\"2020-08-19T21:41:50Z\",\"credentialSubject\":{\"id\":\"did:example:subject\"},\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\"],\"issuer\":\"did:example:issuer\"}],\"proof\":{\"verificationMethod\":\"did:example:wallet\",\"challenge\":\"test-challenge\",\"domain\":\"did:example:wallet\",\"type\":\"JsonWebSignature2020\"}}", actual: (unsignedVPToken as! UnsignedLdpVPToken).dataToSign)
+        assertJsonString(expected: "{\"holder\":\"did:example:wallet\",\"type\":[\"VerifiablePresentation\"],\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\",\"https:\\/\\/w3id.org\\/security\\/suites\\/jws-2020\\/v1\"],\"id\":\"ebc6f1c2\",\"verifiableCredential\":[{\"type\":[\"VerifiableCredential\"],\"issuanceDate\":\"2020-08-19T21:41:50Z\",\"credentialSubject\":{\"id\":\"did:example:subject\"},\"@context\":[\"https:\\/\\/www.w3.org\\/2018\\/credentials\\/v1\"],\"issuer\":\"did:example:issuer\"}],\"proof\":{\"verificationMethod\":\"did:example:wallet\",\"challenge\":\"test-challenge\",\"domain\":\"test-domain\",\"type\":\"JsonWebSignature2020\"}}", actual: (unsignedVPToken as! UnsignedLdpVPToken).dataToSign)
     }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected domain field assignment in Verifiable Presentation token proof construction to properly use the domain parameter value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->