### PR TITLE
feat: add JWK support in SD-JWT cnf claim for key binding

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -43,4 +43,12 @@ fileignoreconfig:
   checksum: bbb2c45b2f6825fd1e5ee979d8c395acf5d479adb61e6e2ec26fc03116625d2d
 - filename: Sources/OpenId4VP/AuthorizationRequest/AuthorizationRequest.swift
   checksum: 5e8889a35d4474e662e5382c5eabd70b407a88af19106189b1949dc46cb6916b
+- filename: Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+  checksum: cd9b4e4663fa3ca5d4dddbc6fbc28021caca6d355e3bc405663227cd8f7055e4
+- filename: Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+  checksum: dd4fc312cb29519c91c4304fae88aa51f560cdc2fd862bd9a76012fd555b6f57
+- filename: Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+  checksum: cd9b4e4663fa3ca5d4dddbc6fbc28021caca6d355e3bc405663227cd8f7055e4
+- filename: Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+  checksum: dd4fc312cb29519c91c4304fae88aa51f560cdc2fd862bd9a76012fd555b6f57
 version: ""

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
@@ -103,11 +103,19 @@ struct UnsignedSdJwtVPTokenBuilder : UnsignedVPTokenBuilder {
             return nil
         }
         
-        guard let keyId = confirmationKeyClaim["kid"] as? String else {
-            throw UnsupportedOperationException(message: "Unsupported cnf format, only 'kid' is supported", className: Self.className)
+        let signingAlgorithm: String
+        let holderKeyReference: String
+        
+        if let jwk = confirmationKeyClaim["jwk"] as? [String: Any] {
+            signingAlgorithm = try resolveAlgFromJwk(jwk)
+            holderKeyReference = try serializeJwkToJson(jwk)
+        } else if let keyId = confirmationKeyClaim["kid"] as? String {
+            let didResolver = DidPublicKeyResolver(networkManager: networkManager)
+            signingAlgorithm = try await didResolver.getJWSAlgorithm(uri: keyId)
+            holderKeyReference = keyId
+        } else {
+            throw UnsupportedOperationException(message: "Unsupported cnf format, must contain 'kid' or 'jwk'", className: Self.className)
         }
-        let didResolver = DidPublicKeyResolver(networkManager: networkManager)
-        let signingAlgorithm = try await didResolver.getJWSAlgorithm(uri: keyId)
         
         let sdHashAlgorithm = sdJWTPayload["_sd_alg"] as? String ?? HashAlgorithm.sha256.rawValue
         let sdHash = try hashData(credential, hashAlgorithm: sdHashAlgorithm, className: Self.className).toBase64UrlEncoded()
@@ -124,7 +132,7 @@ struct UnsignedSdJwtVPTokenBuilder : UnsignedVPTokenBuilder {
         
         let vpToken = UnsignedVPToken(
             format: format,
-            holderKeyReference: keyId,
+            holderKeyReference: holderKeyReference,
             signatureAlgorithm: signingAlgorithm,
             dataToSign: Data(unsignedJWT.utf8)
         )

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -359,4 +359,42 @@ func getJWSAlgorithm(from uri: String) async throws -> String {
     throw UnsupportedOperationException(message: "Unsupported identifier format for JWS algorithm resolution", className: "OpenID4VPUtils")
 }
 
+// MARK: - JWK Utility Functions
+
+private let jwkUtilsClassName = "JwkUtils"
+
+func resolveAlgFromJwk(_ jwk: [String: Any]) throws -> String {
+    if let explicitAlg = jwk["alg"] as? String {
+        return explicitAlg
+    }
+    
+    guard let kty = jwk["kty"] as? String else {
+        throw InvalidData(message: "JWK missing 'kty' field", className: jwkUtilsClassName)
+    }
+    let crv = jwk["crv"] as? String
+    
+    switch (kty.lowercased(), crv?.lowercased()) {
+    case ("okp", "ed25519"):
+        return "EdDSA"
+    case ("ec", "p-256"):
+        return "ES256"
+    case ("ec", "p-384"):
+        return "ES384"
+    case ("ec", "p-521"):
+        return "ES512"
+    case ("rsa", _):
+        return "RS256"
+    default:
+        throw InvalidData(message: "Cannot determine algorithm from JWK (kty=\(kty), crv=\(crv ?? "nil"))", className: jwkUtilsClassName)
+    }
+}
+
+func serializeJwkToJson(_ jwk: [String: Any]) throws -> String {
+    let data = try JSONSerialization.data(withJSONObject: jwk, options: [.sortedKeys])
+    guard let jsonString = String(data: data, encoding: .utf8) else {
+        throw InvalidData(message: "Failed to serialize JWK to JSON string", className: jwkUtilsClassName)
+    }
+    return jsonString
+}
+
 

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
@@ -131,7 +131,7 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         }
     }
 
-    func testBuildThrowsWhenCnfFormatIsUnsupported() async {
+    func testBuildSucceedsWhenCnfContainsJwk() async throws {
         let sdJwtWithJwkCnf = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk0VWw0ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBUQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY0RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.ewogICJpc3N1YW5jZV9kYXRlIjogIjIwMjUtMDgtMTgiLAogICJleHBpcnlfZGF0ZSI6ICIyMDI2LTA4LTI4IiwKICAiaXNzdWluZ19jb3VudHJ5IjogIkRFIiwKICAibmJmIjogMTc1NTQ3NTIwMCwKICAiZXhwIjogMTc4Nzg3NTIwMCwKICAidmN0IjogImh0dHBzOi8vZXhhbXBsZS5ldWRpLmVjLmV1cm9wYS5ldS9jb3IvMSIsCiAgImNuZiI6IHsKICAgICJqd2siOiB7CiAgICAgICAgICJrdHkiOiAiRUMiLAogICAgICAgICAiY3J2IjogIlAtMjU2IiwKICAgICAgICAgIngiOiAiVENBRVIxOVp2dTNPSEY0ajRXNHZmU1ZvSElQMUlMaWxEbHM3dkNlR2VtYyIsCiAgICAgICAgICJ5IjogIlp4amlXV2JaTVFHSFZXS1ZRNGhiU0lpcnNWZnVlY0NFNnQ0alQ5RjJIWlEiCiAgICAgICB9CiAgfSwKICAiaXNzIjogImh0dHBzOi8vZnVua2UuYW5pbW8uaWQiLAogICJpYXQiOiAxNzU2ODk2NjUzLAogICJfc2QiOiBbCiAgICAiQzJQX3FvcTBQdlRvMVlZcnYzXzVGV2k0aUVhWlVHS1lhQ2t6YWtnTUlIYyIsCiAgICAiRjRaZEJQSXgwclFiaG5pZG5TcDFITDctVFJfT0NGcWhXSVZKWjdtQjNGVSIsCiAgICAiVXR2LXRHaElnb0tJS05UYjlndGJyN2JZOUVtUUFNS053dFhqY01zUXBMTSIsCiAgICAiZ3dfRmotNExRRkpDZ3JkVUpwRUJtbTRuemEzMVhSdGFnNVNoX0VQOER6VSIsCiAgICAia2F0NFVBbUs5eG5OR3o1LXhFdkNUdWZlbkFHOVJ1RW94eWtySy1sTktlZyIsCiAgICAib0VCTEtXNFFEOWdjSm5IQkYtWEdla2xBM3g4TDE1dWxDdzVVcXBleWhJcyIsCiAgICAicXRpVUp6bFNMOU0ybjd5eGdoa0lOSnhVSnQ2S2ZaZFBjRGtxaHRWcTR6USIsCiAgICAieTRMeXIyejZBSWRIaHA4ZXQ1VnE5cmhTYjY1c0dpTVgwNkVWWjEtX2k2USIKICBdLAogICJfc2RfYWxnIjogInNoYS0yNTYiCn0.F0gYaWKFzPXoI4pO4mixg6WgN1gM3hfqiJLIgxEAjfQb5yrQEU3G2CCYwJtg7d9bcs9-4lu4ZVS6aWpUJ70UNw~WyI1Njg2Njc5MzY5MTc4MDgxMDA5Nzc0MTQiLCJmYW1pbHlfbmFtZSIsIk11c3Rlcm1hbm4iXQ~WyIxMTc2MjI4NDI0Mzk4MTY4Mzc4NTQ1NTg0IiwiZ2l2ZW5fbmFtZSIsIkVyaWthIl0~WyI1MTI2Mzc4NDkyMDcxOTExMjczMTQwNjAiLCJiaXJ0aF9kYXRlIiwiMTk2NC0wOC0xMiJd~WyIxMTI0MjE5NzQ2NzM0MDA1ODYzMjU3NTAiLCJyZXNpZGVudF9hZGRyZXNzIiwiSGVpZGVzdHJhc3NlIDE3LCA1MTE0NyBLb2xuIl0~WyI1MzcxMzg4MzMyNjMxMDc3MjY5MjQ4NDkiLCJnZW5kZXIiLDJd~WyI5MjcxODEyMjgxOTIyMDY1MDcxOTQyMTMiLCJiaXJ0aF9wbGFjZSIsIkvDtmxuIl0~WyI1MTE2NDk3MzQxMDM5NTU1MTIwMzc0MDQiLCJhcnJpdmFsX2RhdGUiLCIyMDI0LTAzLTAxIl0~WyI5MTQ0NDg4OTMwNzAwNzQ5Mjc3NjMwODkiLCJuYXRpb25hbGl0eSIsIkRFIl0~"
         let builder = UnsignedSdJwtVPTokenBuilder(
             authorizationRequest: getMockAuthorizationRequest(),
@@ -142,9 +142,25 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
             CredentialInputDescriptorMapping(format: .vc_sd_jwt, credential: AnyCodable(sdJwtWithJwkCnf), inputDescriptorId: "input1")
         ]
 
-        await XCTAssertAsyncThrowsError(try await builder.build(credentialInputDescriptorMappings: &mappings)) { error in
-            assertOpenID4VPException(error, expectedMessage: "Unsupported cnf format, only 'kid' is supported", expectedCode: "unsupported_operation")
-        }
+        let (payload, unsignedVPTokens) = try await builder.build(credentialInputDescriptorMappings: &mappings)
+
+        let uuidToKB = try XCTUnwrap(payload as? [String: String])
+        XCTAssertEqual(uuidToKB.count, 1)
+        XCTAssertEqual(unsignedVPTokens.count, 1)
+
+        let token = unsignedVPTokens[0]
+        XCTAssertEqual(token.signatureAlgorithm, "ES256")
+        XCTAssertEqual(token.format, .vc_sd_jwt)
+
+        // holderKeyReference should be the serialized JWK JSON
+        let holderKeyData = try XCTUnwrap(token.holderKeyReference.data(using: .utf8))
+        let holderKeyJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: holderKeyData) as? [String: Any])
+        XCTAssertEqual(holderKeyJson["kty"] as? String, "EC")
+        XCTAssertEqual(holderKeyJson["crv"] as? String, "P-256")
+
+        let identifier = try XCTUnwrap(mappings[0].identifier)
+        let kbJwt = try XCTUnwrap(uuidToKB[identifier])
+        assertKBJwtHeader(kbJwt, expectedHeader: ["alg": "ES256", "typ": "kb+jwt"])
     }
 
     // MARK: - build(credentialToCredentialQueryIdMappings:) — error paths
@@ -213,20 +229,27 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         }
     }
 
-    func testDcqlThrowsWhenCnfFormatIsUnsupportedJwk() async {
+    func testDcqlSucceedsWhenCnfContainsJwk() async throws {
         let sdJwtWithJwkCnf = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk0VWw0ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBUQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY0RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.ewogICJpc3N1YW5jZV9kYXRlIjogIjIwMjUtMDgtMTgiLAogICJleHBpcnlfZGF0ZSI6ICIyMDI2LTA4LTI4IiwKICAiaXNzdWluZ19jb3VudHJ5IjogIkRFIiwKICAibmJmIjogMTc1NTQ3NTIwMCwKICAiZXhwIjogMTc4Nzg3NTIwMCwKICAidmN0IjogImh0dHBzOi8vZXhhbXBsZS5ldWRpLmVjLmV1cm9wYS5ldS9jb3IvMSIsCiAgImNuZiI6IHsKICAgICJqd2siOiB7CiAgICAgICAgICJrdHkiOiAiRUMiLAogICAgICAgICAiY3J2IjogIlAtMjU2IiwKICAgICAgICAgIngiOiAiVENBRVIxOVp2dTNPSEY0ajRXNHZmU1ZvSElQMUlMaWxEbHM3dkNlR2VtYyIsCiAgICAgICAgICJ5IjogIlp4amlXV2JaTVFHSFZXS1ZRNGhiU0lpcnNWZnVlY0NFNnQ0alQ5RjJIWlEiCiAgICAgICB9CiAgfSwKICAiaXNzIjogImh0dHBzOi8vZnVua2UuYW5pbW8uaWQiLAogICJpYXQiOiAxNzU2ODk2NjUzLAogICJfc2QiOiBbCiAgICAiQzJQX3FvcTBQdlRvMVlZcnYzXzVGV2k0aUVhWlVHS1lhQ2t6YWtnTUlIYyIsCiAgICAiRjRaZEJQSXgwclFiaG5pZG5TcDFITDctVFJfT0NGcWhXSVZKWjdtQjNGVSIsCiAgICAiVXR2LXRHaElnb0tJS05UYjlndGJyN2JZOUVtUUFNS053dFhqY01zUXBMTSIsCiAgICAiZ3dfRmotNExRRkpDZ3JkVUpwRUJtbTRuemEzMVhSdGFnNVNoX0VQOER6VSIsCiAgICAia2F0NFVBbUs5eG5OR3o1LXhFdkNUdWZlbkFHOVJ1RW94eWtySy1sTktlZyIsCiAgICAib0VCTEtXNFFEOWdjSm5IQkYtWEdla2xBM3g4TDE1dWxDdzVVcXBleWhJcyIsCiAgICAicXRpVUp6bFNMOU0ybjd5eGdoa0lOSnhVSnQ2S2ZaZFBjRGtxaHRWcTR6USIsCiAgICAieTRMeXIyejZBSWRIaHA4ZXQ1VnE5cmhTYjY1c0dpTVgwNkVWWjEtX2k2USIKICBdLAogICJfc2RfYWxnIjogInNoYS0yNTYiCn0.F0gYaWKFzPXoI4pO4mixg6WgN1gM3hfqiJLIgxEAjfQb5yrQEU3G2CCYwJtg7d9bcs9-4lu4ZVS6aWpUJ70UNw~WyI1Njg2Njc5MzY5MTc4MDgxMDA5Nzc0MTQiLCJmYW1pbHlfbmFtZSIsIk11c3Rlcm1hbm4iXQ~WyIxMTc2MjI4NDI0Mzk4MTY4Mzc4NTQ1NTg0IiwiZ2l2ZW5fbmFtZSIsIkVyaWthIl0~WyI1MTI2Mzc4NDkyMDcxOTExMjczMTQwNjAiLCJiaXJ0aF9kYXRlIiwiMTk2NC0wOC0xMiJd~WyIxMTI0MjE5NzQ2NzM0MDA1ODYzMjU3NTAiLCJyZXNpZGVudF9hZGRyZXNzIiwiSGVpZGVzdHJhc3NlIDE3LCA1MTE0NyBLb2xuIl0~WyI1MzcxMzg4MzMyNjMxMDc3MjY5MjQ4NDkiLCJnZW5kZXIiLDJd~WyI5MjcxODEyMjgxOTIyMDY1MDcxOTQyMTMiLCJiaXJ0aF9wbGFjZSIsIkvDtmxuIl0~WyI1MTE2NDk3MzQxMDM5NTU1MTIwMzc0MDQiLCJhcnJpdmFsX2RhdGUiLCIyMDI0LTAzLTAxIl0~WyI5MTQ0NDg4OTMwNzAwNzQ5Mjc3NjMwODkiLCJuYXRpb25hbGl0eSIsIkRFIl0~"
         let builder = sdJwtBuilderWithDcqlRequest(credentialQueryId: "q1", requireCryptographicHolderBinding: true)
         var mappings = [
             CredentialToCredentialQueryIdMapping(format: .dc_sd_jwt, credential: AnyCodable(sdJwtWithJwkCnf), credentialQueryId: "q1")
         ]
 
-        await XCTAssertAsyncThrowsError(try await builder.build(credentialToCredentialQueryIdMappings: &mappings)) { error in
-            assertOpenID4VPException(
-                error,
-                expectedMessage: "Unsupported cnf format, only 'kid' is supported",
-                expectedCode: "unsupported_operation"
-            )
-        }
+        let (payload, unsignedVPTokens) = try await builder.build(credentialToCredentialQueryIdMappings: &mappings)
+
+        let uuidToKB = try XCTUnwrap(payload as? [String: String])
+        XCTAssertEqual(uuidToKB.count, 1)
+        XCTAssertEqual(unsignedVPTokens.count, 1)
+
+        let token = unsignedVPTokens[0]
+        XCTAssertEqual(token.signatureAlgorithm, "ES256")
+        XCTAssertEqual(token.format, .dc_sd_jwt)
+
+        let holderKeyData = try XCTUnwrap(token.holderKeyReference.data(using: .utf8))
+        let holderKeyJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: holderKeyData) as? [String: Any])
+        XCTAssertEqual(holderKeyJson["kty"] as? String, "EC")
+        XCTAssertEqual(holderKeyJson["crv"] as? String, "P-256")
     }
 
     // MARK: - build(credentialToCredentialQueryIdMappings:) — requireCryptographicHolderBinding = false


### PR DESCRIPTION
## Summary
Support `cnf.jwk` alongside `cnf.kid` in SD-JWT key binding flow.

## Changes
- When `cnf.jwk` is present, algorithm is inferred from the JWK fields (kty/crv) and the serialized JWK JSON is returned as `holderKeyReference`
- When `cnf.kid` is present, existing DID resolution logic is used (no change)
- Throws if neither `kid` nor `jwk` is present in `cnf`

## Files Modified
- `UnsignedSdJwtVPTokenBuilder.swift` — handle jwk branch in `prepareUnsignedKeyBinding`
- `Utils.swift` — added `resolveAlgFromJwk()` and `serializeJwkToJson()` helpers
- `UnsignedSdJwtVPTokenBuilderTests.swift` — updated tests for JWK success path
- `.talismanrc` — updated checksums

## Testing
All 792 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JWK-based key binding in unsigned VP token generation, enabling more flexible credential presentation alongside existing key reference methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->