### PR TITLE
feat: resolve holder key of jwk type in sd-jwt | add: validatePreRegisteredVerifier to walletConfig

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -43,4 +43,12 @@ fileignoreconfig:
   checksum: bbb2c45b2f6825fd1e5ee979d8c395acf5d479adb61e6e2ec26fc03116625d2d
 - filename: Sources/OpenId4VP/AuthorizationRequest/AuthorizationRequest.swift
   checksum: 5e8889a35d4474e662e5382c5eabd70b407a88af19106189b1949dc46cb6916b
+- filename: Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+  checksum: cd9b4e4663fa3ca5d4dddbc6fbc28021caca6d355e3bc405663227cd8f7055e4
+- filename: Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+  checksum: dd4fc312cb29519c91c4304fae88aa51f560cdc2fd862bd9a76012fd555b6f57
+- filename: Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+  checksum: cd9b4e4663fa3ca5d4dddbc6fbc28021caca6d355e3bc405663227cd8f7055e4
+- filename: Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+  checksum: dd4fc312cb29519c91c4304fae88aa51f560cdc2fd862bd9a76012fd555b6f57
 version: ""

--- a/.talismanrc
+++ b/.talismanrc
@@ -44,11 +44,7 @@ fileignoreconfig:
 - filename: Sources/OpenId4VP/AuthorizationRequest/AuthorizationRequest.swift
   checksum: 5e8889a35d4474e662e5382c5eabd70b407a88af19106189b1949dc46cb6916b
 - filename: Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
-  checksum: cd9b4e4663fa3ca5d4dddbc6fbc28021caca6d355e3bc405663227cd8f7055e4
-- filename: Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
-  checksum: dd4fc312cb29519c91c4304fae88aa51f560cdc2fd862bd9a76012fd555b6f57
-- filename: Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
-  checksum: cd9b4e4663fa3ca5d4dddbc6fbc28021caca6d355e3bc405663227cd8f7055e4
+  checksum: bac15638cc64018837eef76eaf47ec830bd1143c450d0c67332f62aa0ed27648
 - filename: Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
   checksum: dd4fc312cb29519c91c4304fae88aa51f560cdc2fd862bd9a76012fd555b6f57
 version: ""

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequest.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequest.swift
@@ -59,7 +59,6 @@ public class AuthorizationRequest: Encodable {
     static func validateAndCreateAuthorizationRequest(urlEncodedAuthorizationRequest: String,
                                                       walletConfig: WalletConfig,
                                                       setResponseUri: @escaping (String) -> Void,
-                                                      shouldValidateClient: Bool,
                                                       walletNonce: String,
                                                       networkManager: NetworkManaging
     ) async throws -> AuthorizationRequest {
@@ -68,7 +67,6 @@ public class AuthorizationRequest: Encodable {
         return try await getAuthorizationRequest(authorizationRequestParameters: extractedQueryParameters,
                                                  walletConfig: walletConfig,
                                                  setResponseUri: setResponseUri,
-                                                 shouldValidateClient: shouldValidateClient,
                                                  walletNonce: walletNonce,
                                                  networkManager: networkManager)
     }
@@ -78,7 +76,6 @@ public class AuthorizationRequest: Encodable {
         authRequest: [String: Any],
         walletConfig: WalletConfig,
         setResponseUri: @escaping (String) -> Void,
-        shouldValidateClient: Bool,
         walletNonce: String,
         networkManager: NetworkManaging
     ) async throws -> AuthorizationRequest {
@@ -86,7 +83,6 @@ public class AuthorizationRequest: Encodable {
             authorizationRequestParameters: authRequest,
             walletConfig: walletConfig,
             setResponseUri: setResponseUri,
-            shouldValidateClient: shouldValidateClient,
             walletNonce: walletNonce,
             networkManager: networkManager
         )
@@ -95,13 +91,11 @@ public class AuthorizationRequest: Encodable {
     private static func getAuthorizationRequest(authorizationRequestParameters: [String: Any],
                                                 walletConfig: WalletConfig,
                                                 setResponseUri: @escaping (String) -> Void,
-                                                shouldValidateClient: Bool,
                                                 walletNonce: String,
                                                 networkManager: NetworkManaging
     ) async throws -> AuthorizationRequest {
         let authorizationRequestHandler = try getAuthorizationRequestHandler(authorizationRequestParameters: authorizationRequestParameters,
                                                                                walletConfig: walletConfig,
-                                                                               shouldValidateClient: shouldValidateClient,
                                                                                setResponseUri: setResponseUri,
                                                                                walletNonce: walletNonce,
                                                                                networkManager: networkManager)

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -141,7 +141,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
                 body?["wallet_metadata"] = jsonStringifiedWalletMetadata
                 shouldValidateWithWalletMetadata = true
             } catch {
-                OpenID4VPException.warn("Error while creating wallet metadata: \(error.localizedDescription). Proceeding without passing Verifier.", className: className)
+                OpenID4VPException.warn("Failed to process wallet metadata for POST request_uri: \(error.localizedDescription). Continuing without metadata.", className: className)
             }
         }
         var response:  NetworkResponse

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
@@ -2,17 +2,14 @@ import Foundation
 import JSONWebKey
 
 class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthorizationRequestHandler {
-    let shouldValidateClient: Bool
     
-    init(clientId: String,
+    override init(clientId: String,
          specVersion: SpecVersion,
          authorizationRequestParameters: [String: Any],
          walletConfig: WalletConfig,
-         shouldValidateClient: Bool,
          setResponseUri: @escaping (String) -> Void,
          walletNonce: String,
          networkManager: NetworkManaging) {
-        self.shouldValidateClient = shouldValidateClient
         super.init(clientId: clientId,
                    specVersion: specVersion,
                    authorizationRequestParameters: authorizationRequestParameters,
@@ -29,7 +26,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
     }
     
     override func validateClientId() throws {
-        if shouldValidateClient {
+        if walletConfig.validatePreRegisteredVerifier {
             guard walletConfig.trustedVerifiers.contains(where: { $0.clientId == authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as? String }) else {
                 throw InvalidVerifier(message: "Verifier is not trusted by the wallet", className: className)
             }
@@ -48,7 +45,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
     
     
     func isUnsignedRequestSupported() throws -> Bool {
-        if shouldValidateClient {
+        if walletConfig.validatePreRegisteredVerifier {
             let clientId = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId]) ?? ""
             let preRegisteredVerifier = try verifier(clientId: clientId)
             return preRegisteredVerifier.allowUnsignedRequest
@@ -75,7 +72,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
     }
     
     override func validateAndParseRequestFields() async throws {
-        if shouldValidateClient {
+        if walletConfig.validatePreRegisteredVerifier {
             let clientId = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as! String
             let preRegisteredClient = try verifier(clientId: clientId)
             

--- a/Sources/OpenID4VP/AuthorizationRequest/Utils/AuthorizationRequestUtils.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/Utils/AuthorizationRequestUtils.swift
@@ -69,7 +69,6 @@ extension KeyedDecodingContainer {
 
 func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any],
                                     walletConfig: WalletConfig,
-                                    shouldValidateClient: Bool,
                                     setResponseUri: @escaping (String) -> Void,
                                     walletNonce: String,
                                     networkManager: NetworkManaging
@@ -86,7 +85,6 @@ func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any]
                                                               specVersion: specVersion,
                                                               authorizationRequestParameters: authorizationRequestParameters,
                                                               walletConfig: walletConfig,
-                                                              shouldValidateClient: shouldValidateClient,
                                                               setResponseUri: setResponseUri,
                                                               walletNonce: walletNonce,
                                                               networkManager: networkManager)
@@ -112,7 +110,6 @@ func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any]
                                                               specVersion: specVersion,
                                                               authorizationRequestParameters: authorizationRequestParameters,
                                                               walletConfig: walletConfig,
-                                                              shouldValidateClient: shouldValidateClient,
                                                               setResponseUri: setResponseUri,
                                                               walletNonce: walletNonce,
                                                               networkManager: networkManager)

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
@@ -103,11 +103,19 @@ struct UnsignedSdJwtVPTokenBuilder : UnsignedVPTokenBuilder {
             return nil
         }
         
-        guard let keyId = confirmationKeyClaim["kid"] as? String else {
-            throw UnsupportedOperationException(message: "Unsupported cnf format, only 'kid' is supported", className: Self.className)
+        let signingAlgorithm: String
+        let holderKeyReference: String
+        
+        if let jwk = confirmationKeyClaim["jwk"] as? [String: Any] {
+            signingAlgorithm = try resolveAlgFromJwk(jwk)
+            holderKeyReference = try serializeJwkToJson(jwk)
+        } else if let keyId = confirmationKeyClaim["kid"] as? String {
+            let didResolver = DidPublicKeyResolver(networkManager: networkManager)
+            signingAlgorithm = try await didResolver.getJWSAlgorithm(uri: keyId)
+            holderKeyReference = keyId
+        } else {
+            throw UnsupportedOperationException(message: "Unsupported cnf format, must contain 'kid' or 'jwk'", className: Self.className)
         }
-        let didResolver = DidPublicKeyResolver(networkManager: networkManager)
-        let signingAlgorithm = try await didResolver.getJWSAlgorithm(uri: keyId)
         
         let sdHashAlgorithm = sdJWTPayload["_sd_alg"] as? String ?? HashAlgorithm.sha256.rawValue
         let sdHash = try hashData(credential, hashAlgorithm: sdHashAlgorithm, className: Self.className).toBase64UrlEncoded()
@@ -124,7 +132,7 @@ struct UnsignedSdJwtVPTokenBuilder : UnsignedVPTokenBuilder {
         
         let vpToken = UnsignedVPToken(
             format: format,
-            holderKeyReference: keyId,
+            holderKeyReference: holderKeyReference,
             signatureAlgorithm: signingAlgorithm,
             dataToSign: Data(unsignedJWT.utf8)
         )

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/SdJwt/UnsignedSdJwtVPTokenBuilder.swift
@@ -105,6 +105,10 @@ struct UnsignedSdJwtVPTokenBuilder : UnsignedVPTokenBuilder {
         
         let signingAlgorithm: String
         let holderKeyReference: String
+
+        if confirmationKeyClaim["jwk"] != nil && confirmationKeyClaim["kid"] != nil {
+            throw InvalidData(message: "Invalid cnf: provide exactly one of 'jwk' or 'kid'", className: Self.className)
+        }
         
         if let jwk = confirmationKeyClaim["jwk"] as? [String: Any] {
             signingAlgorithm = try resolveAlgFromJwk(jwk)

--- a/Sources/OpenID4VP/Common/JWK+JWSAlgorithm.swift
+++ b/Sources/OpenID4VP/Common/JWK+JWSAlgorithm.swift
@@ -1,0 +1,27 @@
+import Foundation
+import JSONWebKey
+
+extension JWK {
+
+    func resolveJWSAlgorithm(className: String) throws -> String {
+        if let explicitAlg = algorithm {
+            guard let supportedAlg = JWSAlgorithm.normalized(explicitAlg) else {
+                throw InvalidData(message: "Unsupported JWK alg '\(explicitAlg)'", className: className)
+            }
+            return supportedAlg
+        }
+
+        switch (keyType, curve) {
+        case (.octetKeyPair, .ed25519):    return JWSAlgorithm.eddsa
+        case (.ellipticCurve, .p256):      return JWSAlgorithm.es256
+        case (.ellipticCurve, .p384):      return JWSAlgorithm.es384
+        case (.ellipticCurve, .secp256k1): return JWSAlgorithm.es256k
+        case (.rsa, _):                    return JWSAlgorithm.rs256
+        default:
+            throw InvalidData(
+                message: "Cannot determine algorithm from JWK (kty=\(keyType.rawValue), crv=\(curve?.rawValue ?? "nil"))",
+                className: className
+            )
+        }
+    }
+}

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -359,4 +359,42 @@ func getJWSAlgorithm(from uri: String) async throws -> String {
     throw UnsupportedOperationException(message: "Unsupported identifier format for JWS algorithm resolution", className: "OpenID4VPUtils")
 }
 
+// MARK: - JWK Utility Functions
+
+private let jwkUtilsClassName = "JwkUtils"
+
+func resolveAlgFromJwk(_ jwk: [String: Any]) throws -> String {
+    if let explicitAlg = jwk["alg"] as? String {
+        return explicitAlg
+    }
+    
+    guard let kty = jwk["kty"] as? String else {
+        throw InvalidData(message: "JWK missing 'kty' field", className: jwkUtilsClassName)
+    }
+    let crv = jwk["crv"] as? String
+    
+    switch (kty.lowercased(), crv?.lowercased()) {
+    case ("okp", "ed25519"):
+        return "EdDSA"
+    case ("ec", "p-256"):
+        return "ES256"
+    case ("ec", "p-384"):
+        return "ES384"
+    case ("ec", "p-521"):
+        return "ES512"
+    case ("rsa", _):
+        return "RS256"
+    default:
+        throw InvalidData(message: "Cannot determine algorithm from JWK (kty=\(kty), crv=\(crv ?? "nil"))", className: jwkUtilsClassName)
+    }
+}
+
+func serializeJwkToJson(_ jwk: [String: Any]) throws -> String {
+    let data = try JSONSerialization.data(withJSONObject: jwk, options: [.sortedKeys])
+    guard let jsonString = String(data: data, encoding: .utf8) else {
+        throw InvalidData(message: "Failed to serialize JWK to JSON string", className: jwkUtilsClassName)
+    }
+    return jsonString
+}
+
 

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -365,7 +365,12 @@ private let jwkUtilsClassName = "JwkUtils"
 
 func resolveAlgFromJwk(_ jwk: [String: Any]) throws -> String {
     if let explicitAlg = jwk["alg"] as? String {
-        return explicitAlg
+        guard let supportedAlgorithm = SignatureAlgorithm.allCases.first(where: {
+            $0.rawValue.caseInsensitiveCompare(explicitAlg) == .orderedSame
+        }) else {
+            throw InvalidData(message: "Unsupported JWK alg '\(explicitAlg)'", className: jwkUtilsClassName)
+        }
+        return supportedAlgorithm.rawValue
     }
     
     guard let kty = jwk["kty"] as? String else {
@@ -396,5 +401,4 @@ func serializeJwkToJson(_ jwk: [String: Any]) throws -> String {
     }
     return jsonString
 }
-
 

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -364,34 +364,14 @@ func getJWSAlgorithm(from uri: String) async throws -> String {
 private let jwkUtilsClassName = "JwkUtils"
 
 func resolveAlgFromJwk(_ jwk: [String: Any]) throws -> String {
-    if let explicitAlg = jwk["alg"] as? String {
-        guard let supportedAlgorithm = SignatureAlgorithm.allCases.first(where: {
-            $0.rawValue.caseInsensitiveCompare(explicitAlg) == .orderedSame
-        }) else {
-            throw InvalidData(message: "Unsupported JWK alg '\(explicitAlg)'", className: jwkUtilsClassName)
-        }
-        return supportedAlgorithm.rawValue
+    let parsedJwk: JWK
+    do {
+        parsedJwk = try convertToInstance(jwk, as: JWK.self)
+    } catch {
+        throw InvalidData(message: "Failed to decode JWK: \(error.localizedDescription)", className: jwkUtilsClassName)
     }
-    
-    guard let kty = jwk["kty"] as? String else {
-        throw InvalidData(message: "JWK missing 'kty' field", className: jwkUtilsClassName)
-    }
-    let crv = jwk["crv"] as? String
-    
-    switch (kty.lowercased(), crv?.lowercased()) {
-    case ("okp", "ed25519"):
-        return "EdDSA"
-    case ("ec", "p-256"):
-        return "ES256"
-    case ("ec", "p-384"):
-        return "ES384"
-    case ("ec", "p-521"):
-        return "ES512"
-    case ("rsa", _):
-        return "RS256"
-    default:
-        throw InvalidData(message: "Cannot determine algorithm from JWK (kty=\(kty), crv=\(crv ?? "nil"))", className: jwkUtilsClassName)
-    }
+
+    return try parsedJwk.resolveJWSAlgorithm(className: jwkUtilsClassName)
 }
 
 func serializeJwkToJson(_ jwk: [String: Any]) throws -> String {

--- a/Sources/OpenID4VP/Constants/JWSAlgorithm.swift
+++ b/Sources/OpenID4VP/Constants/JWSAlgorithm.swift
@@ -9,4 +9,12 @@ enum JWSAlgorithm {
     static let es256 = "ES256"
     static let es384 = "ES384"
     static let es256k = "ES256K"
+
+    /// Algorithms supported for holder / key-binding JWS signing.
+    /// `none` (unsecured JWS) is intentionally excluded.
+    static let supported = [eddsa, rs256, es256, es384, es256k]
+
+    static func normalized(_ value: String) -> String? {
+        supported.first { $0.caseInsensitiveCompare(value) == .orderedSame }
+    }
 }

--- a/Sources/OpenID4VP/Constants/SpecVersion.swift
+++ b/Sources/OpenID4VP/Constants/SpecVersion.swift
@@ -2,3 +2,4 @@ public enum SpecVersion : Codable {
     case draft23
     case v1
 }
+

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -39,8 +39,7 @@ public class OpenID4VP {
     }
     
     public func authenticateVerifier(
-        urlEncodedAuthorizationRequest: String,
-        shouldValidateClient: Bool = true
+        urlEncodedAuthorizationRequest: String
     ) async throws -> AuthorizationRequest {
         // Create a new wallet nonce for each request
         walletNonce = nonceProvider.generateNonce()
@@ -53,7 +52,6 @@ public class OpenID4VP {
                 urlEncodedAuthorizationRequest: urlEncodedAuthorizationRequest,
                 walletConfig: walletConfig,
                 setResponseUri: setResponseUri,
-                shouldValidateClient: shouldValidateClient,
                 walletNonce: walletNonce,
                 networkManager: networkManager
             )
@@ -66,8 +64,7 @@ public class OpenID4VP {
 
 
     public func authenticateVerifier(
-        authorizationRequest: [String: Any],
-        shouldValidateClient: Bool = true
+        authorizationRequest: [String: Any]
     ) async throws -> AuthorizationRequest {
         do {
             walletNonce = nonceProvider.generateNonce()
@@ -79,7 +76,6 @@ public class OpenID4VP {
                 authRequest: authorizationRequest,
                 walletConfig: walletConfig,
                 setResponseUri: setResponseUri,
-                shouldValidateClient: shouldValidateClient,
                 walletNonce: walletNonce,
                 networkManager: networkManager
             )

--- a/Sources/OpenID4VP/Wallet/WalletConfig.swift
+++ b/Sources/OpenID4VP/Wallet/WalletConfig.swift
@@ -172,6 +172,7 @@ public struct WalletConfig: Codable {
         try container.encode(isPresentationDefinitionUriSupported, forKey: .presentationDefinitionUriSupported)
         try container.encode(requestUriMethodsSupported, forKey: .requestUriMethodsSupported)
         try container.encode(trustedVerifiers, forKey: .trustedVerifiers)
+        try container.encode(validatePreRegisteredVerifier, forKey: .validatePreRegisteredVerifier)
     }
 }
 

--- a/Sources/OpenID4VP/Wallet/WalletConfig.swift
+++ b/Sources/OpenID4VP/Wallet/WalletConfig.swift
@@ -13,6 +13,7 @@ public struct WalletConfig: Codable {
     let isPresentationDefinitionUriSupported: Bool
     let requestUriMethodsSupported: [RequestUriMethod]
     let trustedVerifiers: [Verifier]
+    let validatePreRegisteredVerifier: Bool
     
     enum CodingKeys: String, CodingKey {
         case vpFormatsSupported = "vp_formats_supported"
@@ -24,6 +25,7 @@ public struct WalletConfig: Codable {
         case presentationDefinitionUriSupported = "presentation_definition_uri_supported"
         case requestUriMethodsSupported = "request_uri_methods_supported"
         case trustedVerifiers = "trusted_verifiers"
+        case validatePreRegisteredVerifier = "validate_pre_registered_verifier"
     }
     
     public init(
@@ -35,7 +37,8 @@ public struct WalletConfig: Codable {
         responseTypesSupported: [ResponseType] = WalletConfigDefaults.responseTypesSupported,
         isPresentationDefinitionUriSupported: Bool = WalletConfigDefaults.presentationDefinitionUriSupported,
         requestUriMethodsSupported: [RequestUriMethod] = WalletConfigDefaults.requestUriMethodsSupported,
-        trustedVerifiers: [Verifier] = WalletConfigDefaults.trustedVerifiers
+        trustedVerifiers: [Verifier] = WalletConfigDefaults.trustedVerifiers,
+        validatePreRegisteredVerifier: Bool = WalletConfigDefaults.validatePreRegisteredVerifier
     ) {
         self.vpFormatsSupported = vpFormatsSupported
         self.clientIdPrefixesSupported = clientIdPrefixesSupported
@@ -46,6 +49,7 @@ public struct WalletConfig: Codable {
         self.isPresentationDefinitionUriSupported = isPresentationDefinitionUriSupported
         self.requestUriMethodsSupported = requestUriMethodsSupported
         self.trustedVerifiers = trustedVerifiers
+        self.validatePreRegisteredVerifier = validatePreRegisteredVerifier
     }
     
     public init(from decoder: Decoder) throws {
@@ -59,6 +63,7 @@ public struct WalletConfig: Codable {
         self.isPresentationDefinitionUriSupported = try container.decodeIfPresent(Bool.self, forKey: .presentationDefinitionUriSupported) ?? WalletConfigDefaults.presentationDefinitionUriSupported
         self.requestUriMethodsSupported = try container.decodeIfPresent([RequestUriMethod].self, forKey: .requestUriMethodsSupported) ?? WalletConfigDefaults.requestUriMethodsSupported
         self.trustedVerifiers = try container.decodeIfPresent([Verifier].self, forKey: .trustedVerifiers) ?? WalletConfigDefaults.trustedVerifiers
+        self.validatePreRegisteredVerifier = try container.decodeIfPresent(Bool.self, forKey: .validatePreRegisteredVerifier) ?? WalletConfigDefaults.validatePreRegisteredVerifier
     }
     
     private static func parseVPFormatsSupported(from container: KeyedDecodingContainer<CodingKeys>) throws -> [VPFormatType: VPFormatSupported] {
@@ -202,4 +207,7 @@ struct WalletConfigDefaults {
     
     @usableFromInline
     static let trustedVerifiers: [Verifier] = []
+    
+    @usableFromInline
+    static let validatePreRegisteredVerifier : Bool = true
 }

--- a/Sources/OpenID4VP/jwt/KeyResolver/types/did/DidJwkResolver.swift
+++ b/Sources/OpenID4VP/jwt/KeyResolver/types/did/DidJwkResolver.swift
@@ -21,23 +21,8 @@ class DidJwkResolver : BaseDidPublicKeyResolver {
     func extractJWSAlgorithm(parsedDid: ParsedDID) async throws -> String {
         let base64urlJwk = String(parsedDid.id)
         let jwk = try decodeJWK(base64urlJwk)
-        
-        // Priority 1: Use explicit 'alg' field
-        if let alg = jwk.algorithm { return alg }
-        
-        // Priority 2: Map from kty/crv
-        let kty = jwk.keyType
-        let crv = jwk.curve
-        
-        switch (kty, crv) {
-        case (.octetKeyPair, .ed25519): return JWSAlgorithm.eddsa
-        case (.ellipticCurve, .p256):    return JWSAlgorithm.es256
-        case (.ellipticCurve, .p384):    return JWSAlgorithm.es384
-        case (.ellipticCurve, .secp256k1): return JWSAlgorithm.es256k
-        case (.rsa, _): return JWSAlgorithm.rs256
-        default:
-            throw UnsupportedOperationException(message: "Unsupported JWK type or curve", className: Self.className)
-        }
+
+        return try jwk.resolveJWSAlgorithm(className: Self.className)
     }
     
     private func decodeJWK(_ base64urlJwk: String) throws -> JWK {

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
@@ -27,7 +27,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "untrusted-mock-client",
         ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.validateClientId()) { error in
             assertOpenID4VPException(
@@ -41,7 +41,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testThrowExceptionWhenTrustedVerifiersListIsEmpty(){
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "other-mock-client","response_uri": "https://mock-verifier.com"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.validateClientId()) { error in
             assertOpenID4VPException(
@@ -56,38 +56,38 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testReturnTrueForAuthorizationRequestByReferenceSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertTrue(preRegistered.isSignedRequestSupported(), "Pre-registered client id scheme should support authorization request by reference")
     }
     
     
-    func testisUnsignedRequestSupported_shouldValidateClientFalse_returnsTrue() {
+    func testisUnsignedRequestSupported_validatePreregisteredVerifierFalse_returnsTrue() {
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "mock-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: false, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        XCTAssertTrue(try preRegistered.isUnsignedRequestSupported(), "Should return true when shouldValidateClient is false")
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(validatePreregisteredVerifier: false), setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        XCTAssertTrue(try preRegistered.isUnsignedRequestSupported(), "Should return true when validatePreregisteredVerifier is false")
     }
     
-    func testisUnsignedRequestSupported_shouldValidateClientTrue_clientIdNotAvailable_throwsError() {
+    func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdNotAvailable_throwsError() {
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "untrusted-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.isUnsignedRequestSupported()) { error in
             assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
         }
     }
     
-    func testisUnsignedRequestSupported_shouldValidateClientTrue_clientIdAvailable_allowUnsignedFalse_returnsFalse() {
+    func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdAvailable_allowUnsignedFalse_returnsFalse() {
         let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], allowUnsignedRequest: false)]
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "mock-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers), shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         XCTAssertFalse(try preRegistered.isUnsignedRequestSupported(), "Should return false when allowUnsignedRequest is false")
     }
     
-    func testisUnsignedRequestSupported_shouldValidateClientTrue_clientIdAvailable_allowUnsignedTrue_returnsTrue() {
+    func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdAvailable_allowUnsignedTrue_returnsTrue() {
         let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], allowUnsignedRequest: true)]
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "mock-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers), shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         XCTAssertTrue(try preRegistered.isUnsignedRequestSupported(), "Should return true when allowUnsignedRequest is true")
     }
     
@@ -100,7 +100,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let trustedVerifiersWithoutClientMetadata = [
             Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"])
         ]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiersWithoutClientMetadata),shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiersWithoutClientMetadata),setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncNoThrowsError(try await preRegistered.validateAndParseRequestFields(), "Error should not happen when client_metadata is not known to wallet but provided in authorization request")
     }
@@ -110,7 +110,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             "client_id": "mock-client",
             "response_uri": "https://some-other-url.com"
         ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncThrowsError(try await preRegistered.validateAndParseRequestFields()){ error in
             assertOpenID4VPException(error,
@@ -157,7 +157,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             "client_id": "mock-client",
         ]), specVersion: .draft23) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         try? await preRegistered.fetchAuthorizationRequest()
         
@@ -168,7 +168,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "mock-client",
         ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         let expectedWalletMetadata = [
             "authorization_encryption_alg_values_supported": ["ECDH-ES"],
@@ -196,7 +196,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             AuthorizationRequestFieldConstants.clientId: "mock-client",
         ])) as [String : Any]
         
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         await XCTAssertAsyncThrowsError(try preRegistered.getWalletMetadata(walletConfig: walletConfig)) { error in
             assertOpenID4VPException(error,
@@ -208,7 +208,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testExtractPublicKeyThrowErrorWhenPreRegisteredClientNotAvailable() async throws {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue, requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted-client"])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")){ error in
             assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
@@ -221,7 +221,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"])
         ]
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers), shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "EdDSA")){ error in
@@ -231,7 +231,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testClientIdPrefixShouldReturnPreRegistered(){
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertEqual(preRegistered.clientIdPrefix(), ClientIdPrefix.preRegistered.rawValue, "clientIdPrefix should return pre-registered")
     }
@@ -246,7 +246,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
@@ -267,7 +266,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: createWalletConfig(trustedVerifiers: [trustedVerifier]),
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
@@ -289,7 +287,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: createWalletConfig(trustedVerifiers: [trustedVerifier]),
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
@@ -323,7 +320,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: createWalletConfig(trustedVerifiers: [trustedVerifier]),
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
@@ -364,7 +360,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
@@ -383,7 +378,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
@@ -402,7 +396,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           shouldValidateClient: true,
                                                                            setResponseUri: mockSetResponseUri,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestTests.swift
@@ -2,48 +2,46 @@ import XCTest
 @testable import OpenID4VP
 
 final class AuthorizationRequestTests: XCTestCase {
-
+    
     private var mockNetworkManager: MockNetworkManager!
     private var mockSetResponseUri: (String) -> Void = { _ in }
     private var trustedVerifiers: [Verifier]!
-
+    
     override func setUp() {
         super.setUp()
         mockNetworkManager = MockNetworkManager()
         trustedVerifiers = preRegisteredVerifiers
     }
-
+    
     override func tearDown() {
         mockNetworkManager.clearResponses()
         super.tearDown()
     }
-
+    
     // MARK: - validateAndCreateAuthorizationRequest(urlEncodedAuthorizationRequest:)
-
+    
     func testUrlEncodedPathReturnsAuthorizationRequestOnSuccess() async throws {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertEqual(request.responseType, ResponseType.vp_token.rawValue)
         XCTAssertFalse(request.nonce.isEmpty)
         XCTAssertNotNil((request as? AuthorizationPresentationExchangeRequest)?.presentationDefinition)
     }
-
+    
     func testUrlEncodedPathThrowsOnMissingClientId() async {
         let urlWithoutClientId = "OPENID4VP://authorize?response_type=vp_token&nonce=abc"
-
+        
         await XCTAssertAsyncThrowsError(
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: urlWithoutClientId,
-                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
                 setResponseUri: mockSetResponseUri,
-                shouldValidateClient: false,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -55,9 +53,9 @@ final class AuthorizationRequestTests: XCTestCase {
             )
         }
     }
-
+    
     // MARK: - validateAndCreateAuthorizationRequest(authRequest:)
-
+    
     func testDictionaryPathReturnsAuthorizationRequestOnSuccess() async throws {
         let authRequest = createAuthorizationRequest(
             paramList: authRequestWithRedirectUriByValue,
@@ -65,53 +63,50 @@ final class AuthorizationRequestTests: XCTestCase {
             specVersion: .draft23,
             addEncryptionClientMetadataParams: false
         ) as [String: Any]
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertEqual(request.responseType, ResponseType.vp_token.rawValue)
         XCTAssertFalse(request.nonce.isEmpty)
         XCTAssertNotNil((request as? AuthorizationPresentationExchangeRequest)?.presentationDefinition)
     }
-
+    
     func testDictionaryPathPopulatesClientId() async throws {
         let authRequest = createAuthorizationRequest(
             paramList: authRequestWithRedirectUriByValue,
             requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter),
             addEncryptionClientMetadataParams: false
         ) as [String: Any]
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertEqual(request.clientId, "redirect_uri:https://mock-verifier.com")
     }
-
+    
     func testDictionaryPathThrowsOnMissingClientId() async {
         let authRequest: [String: Any] = [
             "response_type": "vp_token",
             "nonce": "test-nonce",
             "presentation_definition": presentationDefinition
         ]
-
+        
         await XCTAssertAsyncThrowsError(
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 authRequest: authRequest,
-                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
                 setResponseUri: mockSetResponseUri,
-                shouldValidateClient: false,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -125,14 +120,13 @@ final class AuthorizationRequestTests: XCTestCase {
     }
     
     // MARK: - Spec Version Draft 23 - URL encoded path
-
+    
     func testUrlEncodedPathReturnsRequestWithPresentationDefinition() async throws {
         // draft23: presentation_definition present → AuthorizationPresentationExchangeRequest
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -141,26 +135,25 @@ final class AuthorizationRequestTests: XCTestCase {
         XCTAssertTrue(request is AuthorizationPresentationExchangeRequest)
         XCTAssertNotNil((request as? AuthorizationPresentationExchangeRequest)?.presentationDefinition)
     }
-
+    
     func testUrlEncodedPathPresentationExchangeRequestHasExpectedFields() async throws {
         // draft23: verify all base fields are populated correctly
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertEqual(request.responseType, ResponseType.vp_token.rawValue)
         XCTAssertFalse(request.nonce.isEmpty)
         XCTAssertNotNil(request.state)
         XCTAssertNotNil(request.responseUri)
     }
-
+    
     // MARK: - Spec Version 1 - URL encoded path
-
+    
     func testUrlEncodedPathReturnsSpecVersion1RequestWithDcqlQuery() async throws {
         // spec v1: dcql_query present → AuthorizationDcqlRequest
         let v1Params = mergeMaps(
@@ -174,21 +167,20 @@ final class AuthorizationRequestTests: XCTestCase {
             applicableFields: ["client_id", "response_uri", "response_type", "response_mode", "nonce", "state", "client_metadata", "dcql_query"],
             addEncryptionClientMetadataParams: false
         )
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: urlEncoded,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertTrue(request is AuthorizationDcqlRequest)
         XCTAssertEqual(request.responseType, ResponseType.vp_token.rawValue)
         XCTAssertFalse(request.nonce.isEmpty)
     }
-
+    
     func testUrlEncodedPathSpecVersion1RequestHasExpectedFields() async throws {
         // spec v1: verify base fields are populated correctly
         let v1Params = mergeMaps(
@@ -202,23 +194,22 @@ final class AuthorizationRequestTests: XCTestCase {
             applicableFields: ["client_id", "response_uri", "response_type", "response_mode", "nonce", "state", "client_metadata", "dcql_query"],
             addEncryptionClientMetadataParams: false
         )
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: urlEncoded,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertEqual(request.clientId, "mock-client")
         XCTAssertNotNil(request.state)
         XCTAssertNotNil(request.responseUri)
     }
-
+    
     // MARK: - Spec Version Draft 23 - Dictionary path
-
+    
     func testDictionaryPathReturnsPresentationExchangeRequestWithPresentationDefinition() async throws {
         // draft23: presentation_definition present → AuthorizationPresentationExchangeRequest
         let authRequest = createAuthorizationRequest(
@@ -227,24 +218,23 @@ final class AuthorizationRequestTests: XCTestCase {
             specVersion: .draft23,
             addEncryptionClientMetadataParams: false
         ) as [String: Any]
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertTrue(request is AuthorizationPresentationExchangeRequest)
         let presentationExchangeRequest = request as? AuthorizationPresentationExchangeRequest
         XCTAssertNotNil(presentationExchangeRequest?.presentationDefinition)
         XCTAssertEqual(presentationExchangeRequest?.presentationDefinition.id, "vp_presentation_definition")
     }
-
+    
     // MARK: - Spec Version 1 - Dictionary path
-
+    
     func testDictionaryPathReturnRequestWithDcqlQuery() async throws {
         // spec v1: dcql_query present → AuthorizationDcqlRequest
         let authRequest = createAuthorizationRequest(
@@ -256,21 +246,20 @@ final class AuthorizationRequestTests: XCTestCase {
             ),
             addEncryptionClientMetadataParams: false
         ) as [String: Any]
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertTrue(request is AuthorizationDcqlRequest)
         XCTAssertEqual(request.responseType, ResponseType.vp_token.rawValue)
         XCTAssertFalse(request.nonce.isEmpty)
     }
-
+    
     func testDictionaryPathSpecVersion1PopulatesClientId() async throws {
         // spec v1: verify clientId is extracted correctly
         let authRequest = createAuthorizationRequest(
@@ -282,19 +271,18 @@ final class AuthorizationRequestTests: XCTestCase {
             ),
             addEncryptionClientMetadataParams: false
         ) as [String: Any]
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertEqual(request.clientId, "mock-client")
     }
-
+    
     func testDictionaryPathSpecVersion1NotContainsPresentationDefinition() async throws {
         // spec v1 (DcqlRequest): must not be cast to draft23 (PresentationExchange) — no presentationDefinition
         let authRequest = createAuthorizationRequest(
@@ -306,30 +294,28 @@ final class AuthorizationRequestTests: XCTestCase {
             specVersion: .v1,
             addEncryptionClientMetadataParams: false
         ) as [String: Any]
-
+        
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
-            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+            walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
             setResponseUri: mockSetResponseUri,
-            shouldValidateClient: false,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
-
+        
         XCTAssertNil(request as? AuthorizationPresentationExchangeRequest)
     }
-
+    
     // MARK: - extractQueryParameters edge cases
-
+    
     func testUrlEncodedPathThrowsWhenNoQuerySeparatorInUrl() async {
         let malformedUrl = "OPENID4VP://authorizeclient_id=mock-client&nonce=abc"
-
+        
         await XCTAssertAsyncThrowsError(
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: malformedUrl,
-                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
                 setResponseUri: mockSetResponseUri,
-                shouldValidateClient: false,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -341,9 +327,9 @@ final class AuthorizationRequestTests: XCTestCase {
             )
         }
     }
-
+    
     // MARK: - Unsupported client_id_prefix
-
+    
     func testUrlEncodedPathHandledAsPreRegisteredClient() async {
         // default branch: client_id with an unrecognised prefix is handled as pre-registered
         let unsupportedSchemeParams = mergeMaps(
@@ -356,31 +342,29 @@ final class AuthorizationRequestTests: XCTestCase {
             applicableFields: authRequestWithPreRegisteredByValue,
             addEncryptionClientMetadataParams: false
         )
-
+        
         await XCTAssertAsyncNoThrowsError(
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: urlEncoded,
-                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
                 setResponseUri: mockSetResponseUri,
-                shouldValidateClient: false,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
         )
     }
-
+    
     func testDictionaryPathDoesNotErrorOutForUnknownClientIDScheme() async {
         // default branch: same check via the dictionary path
         let authRequest: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "https://mock-verifier.com"
         ]), addEncryptionClientMetadataParams: false) as [String : Any]
-
+        
         await XCTAssertAsyncNoThrowsError(
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 authRequest: authRequest,
-                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers),
+                walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validatePreRegisteredVerifier: false),
                 setResponseUri: mockSetResponseUri,
-                shouldValidateClient: false,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/Utils/AuthorizationRequestUtilsTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/Utils/AuthorizationRequestUtilsTests.swift
@@ -60,12 +60,12 @@ class AuthorizationRequestUtilsTests : XCTestCase {
     func testGetAuthorizationRequestHandlerToGiveRespectiveClientIdBasedAuthorizationRequestHandler(){
         let mockSetResponseUri: (String) -> Void = { value in
         }
-        let didAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: DidSchemeClientIdDraft23, walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
-        let preRegisteredSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: preRegisteredSchemeClientIdParameters,  walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+        let didAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: DidSchemeClientIdDraft23, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+        let preRegisteredSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: preRegisteredSchemeClientIdParameters,  walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
         let preRegisteredSchemeClientWithColonSeparatorAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters:  [
             "client_id": "https://mock-verifier.com",
-        ],  walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        let redirectUriSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: redirectUriSchemeClientIdParameter,  walletConfig: walletConfig, shouldValidateClient: true, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        ],  walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let redirectUriSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: redirectUriSchemeClientIdParameter,  walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         
         XCTAssertTrue(didAuthRequestHandler is DecentralizedIdentifierPrefixAuthorizationRequestHandler)
@@ -87,7 +87,7 @@ class AuthorizationRequestUtilsTests : XCTestCase {
         for testCase in testCases {
             let authorizationRequestParametersWithInvalidClientId: [String : Any] = testCase.input as [String : Any]
             
-            XCTAssertThrowsError(try getAuthorizationRequestHandler(authorizationRequestParameters: authorizationRequestParametersWithInvalidClientId,  walletConfig: WalletConfig(), shouldValidateClient: false, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)){ error in
+            XCTAssertThrowsError(try getAuthorizationRequestHandler(authorizationRequestParameters: authorizationRequestParametersWithInvalidClientId,  walletConfig: WalletConfig(validatePreRegisteredVerifier: false), setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)){ error in
                 assertOpenID4VPException(error,
                                          expectedMessage: testCase.expectedError!,
                                          expectedCode: OpenID4VPErrorCodes.invalidRequest

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
@@ -163,6 +163,58 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         assertKBJwtHeader(kbJwt, expectedHeader: ["alg": "ES256", "typ": "kb+jwt"])
     }
 
+    func testBuildThrowsWhenJwkContainsUnsupportedAlgorithm() async throws {
+        let credential = try makeSdJwt(cnf: [
+            "jwk": [
+                "kty": "EC",
+                "crv": "P-256",
+                "alg": "none"
+            ]
+        ])
+        let builder = UnsignedSdJwtVPTokenBuilder(
+            authorizationRequest: getMockAuthorizationRequest(),
+            specVersion: .v1,
+            networkManager: MockNetworkManager()
+        )
+        var mappings = [
+            CredentialInputDescriptorMapping(format: .vc_sd_jwt, credential: AnyCodable(credential), inputDescriptorId: "input1")
+        ]
+
+        await XCTAssertAsyncThrowsError(try await builder.build(credentialInputDescriptorMappings: &mappings)) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Unsupported JWK alg 'none'",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testBuildThrowsWhenCnfContainsBothJwkAndKid() async throws {
+        let credential = try makeSdJwt(cnf: [
+            "jwk": [
+                "kty": "EC",
+                "crv": "P-256"
+            ],
+            "kid": expectedCnfKid
+        ])
+        let builder = UnsignedSdJwtVPTokenBuilder(
+            authorizationRequest: getMockAuthorizationRequest(),
+            specVersion: .v1,
+            networkManager: MockNetworkManager()
+        )
+        var mappings = [
+            CredentialInputDescriptorMapping(format: .vc_sd_jwt, credential: AnyCodable(credential), inputDescriptorId: "input1")
+        ]
+
+        await XCTAssertAsyncThrowsError(try await builder.build(credentialInputDescriptorMappings: &mappings)) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Invalid cnf: provide exactly one of 'jwk' or 'kid'",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
     // MARK: - build(credentialToCredentialQueryIdMappings:) — error paths
 
     func testDcqlThrowsWhenAuthorizationRequestIsNotDcqlRequest() async {
@@ -383,6 +435,15 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func makeSdJwt(cnf: [String: Any]) throws -> String {
+        let header = try JSONSerialization.data(withJSONObject: ["alg": "ES256"]).toBase64UrlEncoded()
+        let payload = try JSONSerialization.data(withJSONObject: [
+            "cnf": cnf,
+            "_sd_alg": HashAlgorithm.sha256.rawValue
+        ]).toBase64UrlEncoded()
+        return "\(header).\(payload).signature"
+    }
 
     private func assertKBJwtHeader(_ kbJwt: String, expectedHeader: [String: Any], file: StaticString = #file, line: UInt = #line) {
         let parts = kbJwt.split(separator: ".")

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
@@ -131,7 +131,7 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         }
     }
 
-    func testBuildThrowsWhenCnfFormatIsUnsupported() async {
+    func testBuildSucceedsWhenCnfContainsJwk() async throws {
         let sdJwtWithJwkCnf = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk0VWw0ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBUQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY0RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.ewogICJpc3N1YW5jZV9kYXRlIjogIjIwMjUtMDgtMTgiLAogICJleHBpcnlfZGF0ZSI6ICIyMDI2LTA4LTI4IiwKICAiaXNzdWluZ19jb3VudHJ5IjogIkRFIiwKICAibmJmIjogMTc1NTQ3NTIwMCwKICAiZXhwIjogMTc4Nzg3NTIwMCwKICAidmN0IjogImh0dHBzOi8vZXhhbXBsZS5ldWRpLmVjLmV1cm9wYS5ldS9jb3IvMSIsCiAgImNuZiI6IHsKICAgICJqd2siOiB7CiAgICAgICAgICJrdHkiOiAiRUMiLAogICAgICAgICAiY3J2IjogIlAtMjU2IiwKICAgICAgICAgIngiOiAiVENBRVIxOVp2dTNPSEY0ajRXNHZmU1ZvSElQMUlMaWxEbHM3dkNlR2VtYyIsCiAgICAgICAgICJ5IjogIlp4amlXV2JaTVFHSFZXS1ZRNGhiU0lpcnNWZnVlY0NFNnQ0alQ5RjJIWlEiCiAgICAgICB9CiAgfSwKICAiaXNzIjogImh0dHBzOi8vZnVua2UuYW5pbW8uaWQiLAogICJpYXQiOiAxNzU2ODk2NjUzLAogICJfc2QiOiBbCiAgICAiQzJQX3FvcTBQdlRvMVlZcnYzXzVGV2k0aUVhWlVHS1lhQ2t6YWtnTUlIYyIsCiAgICAiRjRaZEJQSXgwclFiaG5pZG5TcDFITDctVFJfT0NGcWhXSVZKWjdtQjNGVSIsCiAgICAiVXR2LXRHaElnb0tJS05UYjlndGJyN2JZOUVtUUFNS053dFhqY01zUXBMTSIsCiAgICAiZ3dfRmotNExRRkpDZ3JkVUpwRUJtbTRuemEzMVhSdGFnNVNoX0VQOER6VSIsCiAgICAia2F0NFVBbUs5eG5OR3o1LXhFdkNUdWZlbkFHOVJ1RW94eWtySy1sTktlZyIsCiAgICAib0VCTEtXNFFEOWdjSm5IQkYtWEdla2xBM3g4TDE1dWxDdzVVcXBleWhJcyIsCiAgICAicXRpVUp6bFNMOU0ybjd5eGdoa0lOSnhVSnQ2S2ZaZFBjRGtxaHRWcTR6USIsCiAgICAieTRMeXIyejZBSWRIaHA4ZXQ1VnE5cmhTYjY1c0dpTVgwNkVWWjEtX2k2USIKICBdLAogICJfc2RfYWxnIjogInNoYS0yNTYiCn0.F0gYaWKFzPXoI4pO4mixg6WgN1gM3hfqiJLIgxEAjfQb5yrQEU3G2CCYwJtg7d9bcs9-4lu4ZVS6aWpUJ70UNw~WyI1Njg2Njc5MzY5MTc4MDgxMDA5Nzc0MTQiLCJmYW1pbHlfbmFtZSIsIk11c3Rlcm1hbm4iXQ~WyIxMTc2MjI4NDI0Mzk4MTY4Mzc4NTQ1NTg0IiwiZ2l2ZW5fbmFtZSIsIkVyaWthIl0~WyI1MTI2Mzc4NDkyMDcxOTExMjczMTQwNjAiLCJiaXJ0aF9kYXRlIiwiMTk2NC0wOC0xMiJd~WyIxMTI0MjE5NzQ2NzM0MDA1ODYzMjU3NTAiLCJyZXNpZGVudF9hZGRyZXNzIiwiSGVpZGVzdHJhc3NlIDE3LCA1MTE0NyBLb2xuIl0~WyI1MzcxMzg4MzMyNjMxMDc3MjY5MjQ4NDkiLCJnZW5kZXIiLDJd~WyI5MjcxODEyMjgxOTIyMDY1MDcxOTQyMTMiLCJiaXJ0aF9wbGFjZSIsIkvDtmxuIl0~WyI1MTE2NDk3MzQxMDM5NTU1MTIwMzc0MDQiLCJhcnJpdmFsX2RhdGUiLCIyMDI0LTAzLTAxIl0~WyI5MTQ0NDg4OTMwNzAwNzQ5Mjc3NjMwODkiLCJuYXRpb25hbGl0eSIsIkRFIl0~"
         let builder = UnsignedSdJwtVPTokenBuilder(
             authorizationRequest: getMockAuthorizationRequest(),
@@ -142,9 +142,25 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
             CredentialInputDescriptorMapping(format: .vc_sd_jwt, credential: AnyCodable(sdJwtWithJwkCnf), inputDescriptorId: "input1")
         ]
 
-        await XCTAssertAsyncThrowsError(try await builder.build(credentialInputDescriptorMappings: &mappings)) { error in
-            assertOpenID4VPException(error, expectedMessage: "Unsupported cnf format, only 'kid' is supported", expectedCode: "unsupported_operation")
-        }
+        let (payload, unsignedVPTokens) = try await builder.build(credentialInputDescriptorMappings: &mappings)
+
+        let uuidToKB = try XCTUnwrap(payload as? [String: String])
+        XCTAssertEqual(uuidToKB.count, 1)
+        XCTAssertEqual(unsignedVPTokens.count, 1)
+
+        let token = unsignedVPTokens[0]
+        XCTAssertEqual(token.signatureAlgorithm, "ES256")
+        XCTAssertEqual(token.format, .vc_sd_jwt)
+
+        // holderKeyReference should be the serialized JWK JSON
+        let holderKeyData = try XCTUnwrap(token.holderKeyReference.data(using: .utf8))
+        let holderKeyJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: holderKeyData) as? [String: Any])
+        XCTAssertEqual(holderKeyJson["kty"] as? String, "EC")
+        XCTAssertEqual(holderKeyJson["crv"] as? String, "P-256")
+
+        let identifier = try XCTUnwrap(mappings[0].identifier)
+        let kbJwt = try XCTUnwrap(uuidToKB[identifier])
+        assertKBJwtHeader(kbJwt, expectedHeader: ["alg": "ES256", "typ": "kb+jwt"])
     }
 
     // MARK: - build(credentialToCredentialQueryIdMappings:) — error paths
@@ -213,20 +229,27 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         }
     }
 
-    func testDcqlThrowsWhenCnfFormatIsUnsupportedJwk() async {
+    func testDcqlSucceedsWhenCnfContainsJwk() async throws {
         let sdJwtWithJwkCnf = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCNVRDQ0FZdWdBd0lCQWdJUUdVZEYwa0JpUUdEYXdwKzBkQlNTNWpBS0JnZ3Foa2pPUFFRREFqQWRNUTR3REFZRFZRUURFd1ZCYm1sdGJ6RUxNQWtHQTFVRUJoTUNUa3d3SGhjTk1qVXdOREV5TVRReU16TXdXaGNOTWpZd05UQXlNVFF5TXpNd1dqQWhNUkl3RUFZRFZRUURFd2xqY21Wa2J5QmtZM014Q3pBSkJnTlZCQVlUQWs1TU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRUZYVk5BMGxhYSs1UDJuazVQSkZvdjh4aEJGTno1VU9KQklWc3lrMFNLU2ZxVGZLTUI2UitjRkROaWpkbUJZeXVFYVVnTWd1VWM4aE9Wbm5yZVc5dGhLT0JxRENCcFRBZEJnTlZIUTRFRmdRVVlSOHZGUVRsa2pmMS9ObktlWnh2WTBaejNhQXdEZ1lEVlIwUEFRSC9CQVFEQWdlQU1CVUdBMVVkSlFFQi93UUxNQWtHQnlpQmpGMEZBUUl3SHdZRFZSMGpCQmd3Rm9BVUw5OHdhTll2OVFueElIYjVDRmd4anZaVXRVc3dJUVlEVlIwU0JCb3dHSVlXYUhSMGNITTZMeTltZFc1clpTNWhibWx0Ynk1cFpEQVpCZ05WSFJFRUVqQVFnZzVtZFc1clpTNWhibWx0Ynk1cFpEQUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkJ3ZFMvY0ZCczNhd3RmUDlHRlZrZ1NPSVRRZFBCTUxoc0pCeWpnN2wyTFFJaEFQUUpXeTdxUXNmcTJHcmRwY0dYSHJEVkswdy9YblBGMlhBVDZyVFg4dUNQIiwiTUlJQnp6Q0NBWFdnQXdJQkFnSVFWd0FGb2xXUWltOTRnbXlDaWMzYkNUQUtCZ2dxaGtqT1BRUURBakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d0hoY05NalF3TlRBeU1UUXlNek13V2hjTk1qZ3dOVEF5TVRReU16TXdXakFkTVE0d0RBWURWUVFERXdWQmJtbHRiekVMTUFrR0ExVUVCaE1DVGt3d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRQy9ZeUJwY1JRWDhaWHBIZnJhMVROZFNiUzdxemdIWUhKM21zYklyOFRKTFBOWkk0VWw0ekpsRmRRVklWbHM1KzVDbENiTitKOUZVdmhQR3M0QXpBK280R1dNSUdUTUIwR0ExVWREZ1FXQkJRdjN6Qm8xaS8xQ2ZFZ2R2a0lXREdPOWxTMVN6QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0lRWURWUjBUQkJvd0dJWVdhSFIwY0hNNkx5OW1kVzVyWlM1aGJtbHRieTVwWkRBU0JnTlZIUk1CQWY0RUNEQUdBUUgvQWdFQU1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEJ6T2k4dlpuVnVhMlV1WVc1cGJXOHVhV1F2WTNKc01Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ1RnODBBbXFWSEpMYVp0MnV1aEF0UHFLSVhhZlAyZ2h0ZDlPQ21kRDUxWndJZ0t2VmtyZ1RZbHhTUkFibUtZNk1sa0g4bU0zU05jbkVKazlmR1Z3SkcrKzA9Il19.ewogICJpc3N1YW5jZV9kYXRlIjogIjIwMjUtMDgtMTgiLAogICJleHBpcnlfZGF0ZSI6ICIyMDI2LTA4LTI4IiwKICAiaXNzdWluZ19jb3VudHJ5IjogIkRFIiwKICAibmJmIjogMTc1NTQ3NTIwMCwKICAiZXhwIjogMTc4Nzg3NTIwMCwKICAidmN0IjogImh0dHBzOi8vZXhhbXBsZS5ldWRpLmVjLmV1cm9wYS5ldS9jb3IvMSIsCiAgImNuZiI6IHsKICAgICJqd2siOiB7CiAgICAgICAgICJrdHkiOiAiRUMiLAogICAgICAgICAiY3J2IjogIlAtMjU2IiwKICAgICAgICAgIngiOiAiVENBRVIxOVp2dTNPSEY0ajRXNHZmU1ZvSElQMUlMaWxEbHM3dkNlR2VtYyIsCiAgICAgICAgICJ5IjogIlp4amlXV2JaTVFHSFZXS1ZRNGhiU0lpcnNWZnVlY0NFNnQ0alQ5RjJIWlEiCiAgICAgICB9CiAgfSwKICAiaXNzIjogImh0dHBzOi8vZnVua2UuYW5pbW8uaWQiLAogICJpYXQiOiAxNzU2ODk2NjUzLAogICJfc2QiOiBbCiAgICAiQzJQX3FvcTBQdlRvMVlZcnYzXzVGV2k0aUVhWlVHS1lhQ2t6YWtnTUlIYyIsCiAgICAiRjRaZEJQSXgwclFiaG5pZG5TcDFITDctVFJfT0NGcWhXSVZKWjdtQjNGVSIsCiAgICAiVXR2LXRHaElnb0tJS05UYjlndGJyN2JZOUVtUUFNS053dFhqY01zUXBMTSIsCiAgICAiZ3dfRmotNExRRkpDZ3JkVUpwRUJtbTRuemEzMVhSdGFnNVNoX0VQOER6VSIsCiAgICAia2F0NFVBbUs5eG5OR3o1LXhFdkNUdWZlbkFHOVJ1RW94eWtySy1sTktlZyIsCiAgICAib0VCTEtXNFFEOWdjSm5IQkYtWEdla2xBM3g4TDE1dWxDdzVVcXBleWhJcyIsCiAgICAicXRpVUp6bFNMOU0ybjd5eGdoa0lOSnhVSnQ2S2ZaZFBjRGtxaHRWcTR6USIsCiAgICAieTRMeXIyejZBSWRIaHA4ZXQ1VnE5cmhTYjY1c0dpTVgwNkVWWjEtX2k2USIKICBdLAogICJfc2RfYWxnIjogInNoYS0yNTYiCn0.F0gYaWKFzPXoI4pO4mixg6WgN1gM3hfqiJLIgxEAjfQb5yrQEU3G2CCYwJtg7d9bcs9-4lu4ZVS6aWpUJ70UNw~WyI1Njg2Njc5MzY5MTc4MDgxMDA5Nzc0MTQiLCJmYW1pbHlfbmFtZSIsIk11c3Rlcm1hbm4iXQ~WyIxMTc2MjI4NDI0Mzk4MTY4Mzc4NTQ1NTg0IiwiZ2l2ZW5fbmFtZSIsIkVyaWthIl0~WyI1MTI2Mzc4NDkyMDcxOTExMjczMTQwNjAiLCJiaXJ0aF9kYXRlIiwiMTk2NC0wOC0xMiJd~WyIxMTI0MjE5NzQ2NzM0MDA1ODYzMjU3NTAiLCJyZXNpZGVudF9hZGRyZXNzIiwiSGVpZGVzdHJhc3NlIDE3LCA1MTE0NyBLb2xuIl0~WyI1MzcxMzg4MzMyNjMxMDc3MjY5MjQ4NDkiLCJnZW5kZXIiLDJd~WyI5MjcxODEyMjgxOTIyMDY1MDcxOTQyMTMiLCJiaXJ0aF9wbGFjZSIsIkvDtmxuIl0~WyI1MTE2NDk3MzQxMDM5NTU1MTIwMzc0MDQiLCJhcnJpdmFsX2RhdGUiLCIyMDI0LTAzLTAxIl0~WyI5MTQ0NDg4OTMwNzAwNzQ5Mjc3NjMwODkiLCJuYXRpb25hbGl0eSIsIkRFIl0~"
         let builder = sdJwtBuilderWithDcqlRequest(credentialQueryId: "q1", requireCryptographicHolderBinding: true)
         var mappings = [
             CredentialToCredentialQueryIdMapping(format: .dc_sd_jwt, credential: AnyCodable(sdJwtWithJwkCnf), credentialQueryId: "q1")
         ]
 
-        await XCTAssertAsyncThrowsError(try await builder.build(credentialToCredentialQueryIdMappings: &mappings)) { error in
-            assertOpenID4VPException(
-                error,
-                expectedMessage: "Unsupported cnf format, only 'kid' is supported",
-                expectedCode: "unsupported_operation"
-            )
-        }
+        let (payload, unsignedVPTokens) = try await builder.build(credentialToCredentialQueryIdMappings: &mappings)
+
+        let uuidToKB = try XCTUnwrap(payload as? [String: String])
+        XCTAssertEqual(uuidToKB.count, 1)
+        XCTAssertEqual(unsignedVPTokens.count, 1)
+
+        let token = unsignedVPTokens[0]
+        XCTAssertEqual(token.signatureAlgorithm, "ES256")
+        XCTAssertEqual(token.format, .dc_sd_jwt)
+
+        let holderKeyData = try XCTUnwrap(token.holderKeyReference.data(using: .utf8))
+        let holderKeyJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: holderKeyData) as? [String: Any])
+        XCTAssertEqual(holderKeyJson["kty"] as? String, "EC")
+        XCTAssertEqual(holderKeyJson["crv"] as? String, "P-256")
     }
 
     // MARK: - build(credentialToCredentialQueryIdMappings:) — requireCryptographicHolderBinding = false

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedSdJwtVPTokenBuilderTests.swift
@@ -215,6 +215,28 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         }
     }
 
+    func testBuildThrowsWhenCnfContainsNeitherJwkNorKid() async throws {
+        let credential = try makeSdJwt(cnf: [
+            "unsupported": "value"
+        ])
+        let builder = UnsignedSdJwtVPTokenBuilder(
+            authorizationRequest: getMockAuthorizationRequest(),
+            specVersion: .v1,
+            networkManager: MockNetworkManager()
+        )
+        var mappings = [
+            CredentialInputDescriptorMapping(format: .vc_sd_jwt, credential: AnyCodable(credential), inputDescriptorId: "input1")
+        ]
+
+        await XCTAssertAsyncThrowsError(try await builder.build(credentialInputDescriptorMappings: &mappings)) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Unsupported cnf format, must contain 'kid' or 'jwk'",
+                expectedCode: "unsupported_operation"
+            )
+        }
+    }
+
     // MARK: - build(credentialToCredentialQueryIdMappings:) — error paths
 
     func testDcqlThrowsWhenAuthorizationRequestIsNotDcqlRequest() async {
@@ -302,6 +324,68 @@ final class UnsignedSdJwtVPTokenBuilderTests: XCTestCase {
         let holderKeyJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: holderKeyData) as? [String: Any])
         XCTAssertEqual(holderKeyJson["kty"] as? String, "EC")
         XCTAssertEqual(holderKeyJson["crv"] as? String, "P-256")
+    }
+
+    func testDcqlThrowsWhenJwkContainsUnsupportedAlgorithm() async throws {
+        let credential = try makeSdJwt(cnf: [
+            "jwk": [
+                "kty": "EC",
+                "crv": "P-256",
+                "alg": "none"
+            ]
+        ])
+        let builder = sdJwtBuilderWithDcqlRequest(credentialQueryId: "q1", requireCryptographicHolderBinding: true)
+        var mappings = [
+            CredentialToCredentialQueryIdMapping(format: .dc_sd_jwt, credential: AnyCodable(credential), credentialQueryId: "q1")
+        ]
+
+        await XCTAssertAsyncThrowsError(try await builder.build(credentialToCredentialQueryIdMappings: &mappings)) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Unsupported JWK alg 'none'",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testDcqlThrowsWhenCnfContainsBothJwkAndKid() async throws {
+        let credential = try makeSdJwt(cnf: [
+            "jwk": [
+                "kty": "EC",
+                "crv": "P-256"
+            ],
+            "kid": expectedCnfKid
+        ])
+        let builder = sdJwtBuilderWithDcqlRequest(credentialQueryId: "q1", requireCryptographicHolderBinding: true)
+        var mappings = [
+            CredentialToCredentialQueryIdMapping(format: .dc_sd_jwt, credential: AnyCodable(credential), credentialQueryId: "q1")
+        ]
+
+        await XCTAssertAsyncThrowsError(try await builder.build(credentialToCredentialQueryIdMappings: &mappings)) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Invalid cnf: provide exactly one of 'jwk' or 'kid'",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testDcqlThrowsWhenCnfContainsNeitherJwkNorKid() async throws {
+        let credential = try makeSdJwt(cnf: [
+            "unsupported": "value"
+        ])
+        let builder = sdJwtBuilderWithDcqlRequest(credentialQueryId: "q1", requireCryptographicHolderBinding: true)
+        var mappings = [
+            CredentialToCredentialQueryIdMapping(format: .dc_sd_jwt, credential: AnyCodable(credential), credentialQueryId: "q1")
+        ]
+
+        await XCTAssertAsyncThrowsError(try await builder.build(credentialToCredentialQueryIdMappings: &mappings)) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Unsupported cnf format, must contain 'kid' or 'jwk'",
+                expectedCode: "unsupported_operation"
+            )
+        }
     }
 
     // MARK: - build(credentialToCredentialQueryIdMappings:) — requireCryptographicHolderBinding = false

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -52,11 +52,11 @@ class OpenID4VPTests: XCTestCase {
 
     func testWalletNonceIsDifferentForEveryAuthenticateVerifierCall() async {
         let openID4VP = OpenID4VP(traceabilityId: "trace-id")
-        _ = try! await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri,shouldValidateClient: true)
+        _ = try! await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri)
         let firstMirror = Mirror(reflecting: openID4VP as Any)
         let firstNonce = firstMirror.children.first(where: { $0.label == "walletNonce" })?.value as? String
 
-        _ = try! await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri,shouldValidateClient: true)
+        _ = try! await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri)
         let secondMirror = Mirror(reflecting: openID4VP as Any)
         let secondNonce = secondMirror.children.first(where: { $0.label == "walletNonce" })?.value as? String
 
@@ -66,7 +66,7 @@ class OpenID4VPTests: XCTestCase {
     // client_id_prefix = redirect_uri
     func testAuthorizationRequestJsonStringConversion() async {
         do {
-            let decoded = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri,shouldValidateClient: true)
+            let decoded = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri)
             let jsonData = try JSONEncoder().encode(decoded)
             let authorizationRequestJsonString = String(decoding: jsonData, as: UTF8.self)
 
@@ -79,7 +79,7 @@ class OpenID4VPTests: XCTestCase {
     // client_id_prefix = redirect_uri, test with deprecated authenticateVerifier including trustedVerifierJSON parameter
     func testAuthorizationRequestJsonStringConversionDeprecatedMethod() async {
         do {
-            let decoded = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri,shouldValidateClient: true)
+            let decoded = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri)
             let jsonData = try JSONEncoder().encode(decoded)
             let authorizationRequestJsonString = String(decoding: jsonData, as: UTF8.self)
 
@@ -92,7 +92,7 @@ class OpenID4VPTests: XCTestCase {
     // client_id_prefix = redirect_uri, response_mode = fragment
     func testInvalidResponseModeWithRedirectUriScheme() async {
         let result = await Task {
-            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testVPRequestWithRedirectUriAndClientIdNotEqual,shouldValidateClient: true)
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testVPRequestWithRedirectUriAndClientIdNotEqual)
         }.result
 
         switch result {
@@ -114,29 +114,32 @@ class OpenID4VPTests: XCTestCase {
 
         await XCTAssertNoThrowAndVerifyAsync(
             try await openID4VP.authenticateVerifier(
-                urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
-                shouldValidateClient: true
+                urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri
             )
         ) { authorizationRequest in
             XCTAssertEqual(authorizationRequest.clientId, "mock-client")
         }
     }
 
-    // client_id_prefix = pre-registered, validation of client via shouldValidateClient
+    // client_id_prefix = pre-registered, validation of client via validatePreregisteredVerifier
 
-    func testAuthenticateVerifierWithShouldValidateClientFalse() async throws {
-        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(
-            urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier,
-            shouldValidateClient: false
-        ), "should not throw even though the client ID isn't in the trusted list because shouldValidateClient is false") { error in
-            assertOpenID4VPException(error, expectedMessage: "Authorization Request Object must be a signed JWT", expectedCode: OpenID4VPErrorCodes.invalidRequest)
-        }
+    func testAuthenticateVerifierWithValidatePreregisteredVerifierFalse() async throws {
+        openID4VP = OpenID4VP(
+            traceabilityId: "AXESWSAW123",
+            networkManager: mockNetworkManager,
+            walletConfig: WalletConfig(trustedVerifiers: preRegisteredVerifiers, validatePreRegisteredVerifier: false),
+            nonceProvider: MockNonceProvider(),
+            jsonLdCanonicalizer: { _ in "Y2Fub25pY2FsaXplZA" }
+        )
+        
+        await XCTAssertAsyncNoThrowsError(try await openID4VP.authenticateVerifier(
+            urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier
+        ), "should not throw even though the client ID isn't in the trusted list because validatePreregisteredVerifier is false")
     }
 
-    func testAuthenticateVerifierWithShouldValidateClientTrue() async throws {
+    func testAuthenticateVerifierWithValidatePreregisteredVerifierTrue() async throws {
         await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(
-            urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier,
-            shouldValidateClient: true
+            urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier
         )) { error in
             assertOpenID4VPException(
                 error,
@@ -146,7 +149,7 @@ class OpenID4VPTests: XCTestCase {
         }
     }
 
-    func testAuthenticateVerifierWithoutShouldValidateClientParam() async throws {
+    func testAuthenticateVerifierWithoutValidatePreregisteredVerifierParam() async throws {
         await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(
             urlEncodedAuthorizationRequest: testUrlEncodedAuthRequestOfUntrustedVerifier
         )) { error in
@@ -169,7 +172,7 @@ class OpenID4VPTests: XCTestCase {
         )
         
         let result = await Task {
-            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthorizationRequestWithInvalidClientMetadata, shouldValidateClient: true)
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthorizationRequestWithInvalidClientMetadata)
         }.result
 
         switch result {
@@ -187,7 +190,7 @@ class OpenID4VPTests: XCTestCase {
     func testShouldConstructAuthorizationRequestSuccessfullyWhenPresentationDefinitionIsSentByReference() async {
         mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/presentation-definition", responseBody: convertToJsonString(presentationDefinition))
         do {
-            let authorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthRequestWithPresentationDefinitionUri,shouldValidateClient: true)
+            let authorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: urlEncodedAuthRequestWithPresentationDefinitionUri)
             XCTAssertNotNil(authorizationRequest)
             XCTAssertEqual("mock-client", authorizationRequest.clientId)
         } catch {
@@ -202,7 +205,7 @@ class OpenID4VPTests: XCTestCase {
 
         let decodedAuthorizationRequest: Any?
         do {
-            decodedAuthorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid,shouldValidateClient: true)
+            decodedAuthorizationRequest = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid)
         } catch {
             decodedAuthorizationRequest = nil
             XCTFail("Should not get error but got error - \(error)")
@@ -223,7 +226,7 @@ class OpenID4VPTests: XCTestCase {
             responseBody: didResponse
         )
 
-        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid,shouldValidateClient: true)) { error in
+        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid)) { error in
             assertOpenID4VPException(
                 error,
                 expectedMessage: "Request URI response validation failed - JWS proof verification failed",
@@ -240,7 +243,7 @@ class OpenID4VPTests: XCTestCase {
         )
         mockNetworkManager.setMockResponse(for: didDocumentUrl, responseBody: didResponse)
 
-        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInValidSignedVPRequestWithDidAndClientIdDifferent,shouldValidateClient: true)) { error in
+        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInValidSignedVPRequestWithDidAndClientIdDifferent)) { error in
             assertOpenID4VPException(
                 error,
                 expectedMessage: "Client Id mismatch in Authorization Request parameter and the Request Object",
@@ -254,7 +257,7 @@ class OpenID4VPTests: XCTestCase {
         mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/verifier/get-auth-request-obj", response: (invalidJwtResponseWithoutKid, httpUrlResponseForJWS))
         mockNetworkManager.setMockResponse(for: didDocumentUrl, responseBody: didResponse)
 
-        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid,shouldValidateClient: true)) {
+        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid)) {
             error in
             assertOpenID4VPException(
                 error,
@@ -267,9 +270,16 @@ class OpenID4VPTests: XCTestCase {
     // client_id_prefix = redirect_uri, Client id validation is false
     func testReturnDataForValidRequestWhenClientValidationIsFalse() async {
         let decoded: Any?
+        openID4VP = OpenID4VP(
+            traceabilityId: "AXESWSAW123",
+            networkManager: mockNetworkManager,
+            walletConfig: WalletConfig(trustedVerifiers: preRegisteredVerifiers, validatePreRegisteredVerifier: false),
+            nonceProvider: MockNonceProvider(),
+            jsonLdCanonicalizer: { _ in "Y2Fub25pY2FsaXplZA" }
+        )
 
         do {
-            decoded = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri,shouldValidateClient: false)
+            decoded = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithRedirectUri)
         } catch {
             decoded = nil
             XCTFail("should not get error but got error \(error)")
@@ -280,7 +290,7 @@ class OpenID4VPTests: XCTestCase {
 
     func testMissingPresentationDefinitionFields() async {
         let result = await Task {
-            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInvalidPresentationDefinitionVPRequest,shouldValidateClient: true)
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInvalidPresentationDefinitionVPRequest)
         }.result
 
         switch result {
@@ -302,8 +312,7 @@ class OpenID4VPTests: XCTestCase {
 
         do {
             _ = try await openID4VP.authenticateVerifier(
-                urlEncodedAuthorizationRequest: mockUrlEncodedVPRequestWithDirectPostJwt,
-                shouldValidateClient: true
+                urlEncodedAuthorizationRequest: mockUrlEncodedVPRequestWithDirectPostJwt
             )
 
             let mockCredentials: [String: [Credential]] = [
@@ -326,7 +335,7 @@ class OpenID4VPTests: XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl, responseBody: didResponse)
 
         // first call
-        _ = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid,shouldValidateClient: true)
+        _ = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid)
         let firstMirror = Mirror(reflecting: openID4VP as Any)
         let firstResponseUri = firstMirror.children.first(where: { $0.label == "responseUri" })?.value as? String
         let firstAuthorizationRequest = firstMirror.children.first(where: { $0.label == "authorizationRequest" })?.value as? AuthorizationRequest
@@ -345,7 +354,7 @@ class OpenID4VPTests: XCTestCase {
             responseBody: didResponse
         )
 
-        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid,shouldValidateClient: true)) { error in
+        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid)) { error in
             assertOpenID4VPException(
                 error,
                 expectedMessage: "Request URI response validation failed - JWS proof verification failed",
@@ -390,7 +399,7 @@ class OpenID4VPTests: XCTestCase {
     func testThrownExceptionHavingVerifierResponse() async {
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: "{\"message\":\"Some additional info\",\"redirect_uri\":\"https://mock-verifier.com/redirect#response_code=200\"}")
 
-        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInvalidPresentationDefinitionVPRequest,shouldValidateClient: true)) { error in
+        await XCTAssertAsyncThrowsError(try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testInvalidPresentationDefinitionVPRequest)) { error in
             assertOpenID4VPException(
                 error,
                 expectedMessage: "Missing Input: presentation_definition->id param is required",
@@ -425,8 +434,7 @@ class OpenID4VPTests: XCTestCase {
 
         do {
             _ = try await openID4VP.authenticateVerifier(
-                authorizationRequest: authorizationRequest,
-                shouldValidateClient: true
+                authorizationRequest: authorizationRequest
             )
         } catch let error {
             print(error)

--- a/Tests/OpenID4VPTests/TestData/TestData.swift
+++ b/Tests/OpenID4VPTests/TestData/TestData.swift
@@ -549,7 +549,7 @@ let testVPRequestWithRedirectUriAndClientIdNotEqual = createUrlEncodedAuthorizat
 //client_id_prefix = pre-registered
 let testValidUrlEncodedVPRequestWithResponseUri = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters), clientIdPrefix: .preRegistered,specVersion: .draft23 , addEncryptionClientMetadataParams: false)
 
-let testUrlEncodedAuthRequestOfUntrustedVerifier = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted_client"]), verifierSentAuthRequestByReference: true, clientIdPrefix: .preRegistered)
+let testUrlEncodedAuthRequestOfUntrustedVerifier = createUrlEncodedAuthorizationRequest(requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted_client"]), verifierSentAuthRequestByReference: false, clientIdPrefix: .preRegistered, addEncryptionClientMetadataParams: false)
 
 
 // jwt -> client_id_prefix = did

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -292,7 +292,8 @@ func createWalletConfig(
     authorizationEncryptionEncValuesSupported: [EncryptionMethod]? = [.a256GCM],
     responseTypesSupported: [ResponseType] = [.vp_token],
     responseMode: ResponseMode = .directPost,
-    trustedVerifiers: [Verifier] = preRegisteredVerifiers
+    trustedVerifiers: [Verifier] = preRegisteredVerifiers,
+    validatePreregisteredVerifier: Bool = true
 ) -> WalletConfig {
     return WalletConfig(
         vpFormatsSupported: vpFormatsSupported,
@@ -301,7 +302,8 @@ func createWalletConfig(
         authorizationEncryptionAlgValuesSupported: authorizationEncryptionAlgValuesSupported,
         authorizationEncryptionEncValuesSupported: authorizationEncryptionEncValuesSupported,
         responseTypesSupported: responseTypesSupported,
-        trustedVerifiers: trustedVerifiers
+        trustedVerifiers: trustedVerifiers,
+        validatePreRegisteredVerifier: validatePreregisteredVerifier
     )
 }
 

--- a/Tests/OpenID4VPTests/Wallet/WalletConfigTests.swift
+++ b/Tests/OpenID4VPTests/Wallet/WalletConfigTests.swift
@@ -264,7 +264,8 @@ final class WalletConfigTests: XCTestCase {
             "response_types_supported",
             "request_uri_methods_supported",
             "trusted_verifiers",
-            "vp_formats_supported"
+            "vp_formats_supported",
+            "validate_pre_registered_verifier"
         ].sorted())
     }
 

--- a/Tests/OpenID4VPTests/Wallet/WalletConfigTests.swift
+++ b/Tests/OpenID4VPTests/Wallet/WalletConfigTests.swift
@@ -18,7 +18,8 @@ final class WalletConfigTests: XCTestCase {
         responseTypes: [ResponseType] = [.vp_token],
         presentationDefinitionUriSupported: Bool = true,
         requestUriMethods: [RequestUriMethod] = [.get],
-        trustedVerifiers: [Verifier] = []
+        trustedVerifiers: [Verifier] = [],
+        validatePreRegisteredVerifier: Bool = true
     ) -> WalletConfig {
         let formats = vpFormats ?? [.ldp_vc: ldpVc, .mso_mdoc: msoMdoc, .dc_sd_jwt: sdJwt]
         return WalletConfig(
@@ -30,7 +31,8 @@ final class WalletConfigTests: XCTestCase {
             responseTypesSupported: responseTypes,
             isPresentationDefinitionUriSupported: presentationDefinitionUriSupported,
             requestUriMethodsSupported: requestUriMethods,
-            trustedVerifiers: trustedVerifiers
+            trustedVerifiers: trustedVerifiers,
+            validatePreRegisteredVerifier: validatePreRegisteredVerifier
         )
     }
 
@@ -57,7 +59,8 @@ final class WalletConfigTests: XCTestCase {
             responseTypes: [.vp_token],
             presentationDefinitionUriSupported: false,
             requestUriMethods: [.get, .post],
-            trustedVerifiers: [verifier]
+            trustedVerifiers: [verifier],
+            validatePreRegisteredVerifier: false
         )
         let formats = try encodeVpFormats(config)
         XCTAssertEqual(formats.keys.sorted(), ["dc+sd-jwt", "ldp_vc", "mso_mdoc"])
@@ -70,6 +73,7 @@ final class WalletConfigTests: XCTestCase {
         XCTAssertEqual(config.requestUriMethodsSupported, [.get, .post])
         XCTAssertEqual(config.trustedVerifiers.map { $0.clientId }, ["v1"])
         XCTAssertEqual(config.trustedVerifiers.map { $0.responseUris }, [["https://v.example.com"]])
+        XCTAssertFalse(config.validatePreRegisteredVerifier)
     }
 
     func testDefaultInitUsesWalletConfigDefaults() throws {


### PR DESCRIPTION
## Add validatePreRegisteredVerifier as well to WalletConfig

- **Config name**: validatePreRegisteredVerifier
- **Type**: Bool
- **Description**: Flag indicating about whether the VP request’s client ID is recognized to be a “pre-registered“ client as per the client ID value in the VP request, needs to be validated against the Wallet’s pre-registered verifer list (trustedVerifier’s param in walletConfig)
- **Previously available as**: `shouldValidateClient` in `authenticateVerifier` method

Relates: https://github.com/inji/inji-wallet/issues/2437

## feat: resolve holder key of jwk type in sd-jwt

- Extension of SD-JWT holder key extraction to jwk format

Relates : https://github.com/inji/inji-wallet/issues/2466

Author(s): @abhip2565 @KiruthikaJeyashankar 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Verifier authentication API simplified by removing the optional client-validation parameter.

* **New Features**
  * Wallet configuration adds a toggle to enable/disable pre-registered verifier validation.

* **Improvements**
  * VP token creation now supports embedded JWK holder bindings and improved algorithm resolution.
  * JWS algorithm handling normalized across key types.

* **Bug Fixes**
  * Clarified warning when wallet metadata processing for request references fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->