### PR TITLE
refactor: rename *vcFormatSupported to *VpFormatSupported

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadata.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadata.swift
@@ -46,11 +46,11 @@ public struct ClientMetadata: Codable {
             for key in vpFormatsContainer.allKeys {
                 switch key {
                 case .ldp_vc, .ldp_vp:
-                    decodedFormats[key.rawValue] = try vpFormatsContainer.decode(LdpVcFormatSupported.self, forKey: key)
+                    decodedFormats[key.rawValue] = try vpFormatsContainer.decode(LdpVpFormatSupported.self, forKey: key)
                 case .mso_mdoc:
-                    decodedFormats[key.rawValue] = try vpFormatsContainer.decode(MsoMdocVcFormatSupported.self, forKey: key)
+                    decodedFormats[key.rawValue] = try vpFormatsContainer.decode(MsoMdocVpFormatSupported.self, forKey: key)
                 case .dc_sd_jwt, .vc_sd_jwt:
-                    decodedFormats[key.rawValue] = try vpFormatsContainer.decode(SdJwtVcFormatSupported.self, forKey: key)
+                    decodedFormats[key.rawValue] = try vpFormatsContainer.decode(SdJwtVpFormatSupported.self, forKey: key)
                 }
             }
             self.vpFormatsSupported = decodedFormats
@@ -77,15 +77,15 @@ public struct ClientMetadata: Codable {
             guard let formatType = VPFormatType(rawValue: key) else { continue }
             switch formatType {
             case .ldp_vc, .ldp_vp:
-                if let typed = value as? LdpVcFormatSupported {
+                if let typed = value as? LdpVpFormatSupported {
                     try vpFormatsContainer.encode(typed, forKey: formatType)
                 }
             case .mso_mdoc:
-                if let typed = value as? MsoMdocVcFormatSupported {
+                if let typed = value as? MsoMdocVpFormatSupported {
                     try vpFormatsContainer.encode(typed, forKey: formatType)
                 }
             case .dc_sd_jwt, .vc_sd_jwt:
-                if let typed = value as? SdJwtVcFormatSupported {
+                if let typed = value as? SdJwtVpFormatSupported {
                     try vpFormatsContainer.encode(typed, forKey: formatType)
                 }
             }

--- a/Sources/OpenID4VP/Wallet/VPFormatSupported.swift
+++ b/Sources/OpenID4VP/Wallet/VPFormatSupported.swift
@@ -2,7 +2,7 @@ public protocol VPFormatSupported: Codable {
     func toAlgValuesSupported() -> [String]?
 }
 
-public struct LdpVcFormatSupported: VPFormatSupported, Codable {
+public struct LdpVpFormatSupported: VPFormatSupported, Codable {
     let proofTypeValues: [ProofType]?
     let cryptoSuiteValues: [String]?
     
@@ -52,7 +52,7 @@ public struct LdpVcFormatSupported: VPFormatSupported, Codable {
     }
 }
 
-public struct MsoMdocVcFormatSupported: VPFormatSupported, Codable {
+public struct MsoMdocVpFormatSupported: VPFormatSupported, Codable {
     let issuerAuthAlgValues: [Int]?
     let deviceAuthAlgValues: [Int]?
     private let algorithmValueNameMap: [Int: String] = [
@@ -79,7 +79,7 @@ public struct MsoMdocVcFormatSupported: VPFormatSupported, Codable {
 }
 
 
-public struct SdJwtVcFormatSupported: VPFormatSupported, Codable {
+public struct SdJwtVpFormatSupported: VPFormatSupported, Codable {
     let sdJwtAlgValues: [String]?
     let kbJwtAlgValues: [String]?
     

--- a/Sources/OpenID4VP/Wallet/WalletConfig.swift
+++ b/Sources/OpenID4VP/Wallet/WalletConfig.swift
@@ -70,11 +70,11 @@ public struct WalletConfig: Codable {
         for key in vpFormatsContainer.allKeys {
             switch key {
             case .ldp_vc, .ldp_vp:
-                decodedFormats[key] = try vpFormatsContainer.decode(LdpVcFormatSupported.self, forKey: key)
+                decodedFormats[key] = try vpFormatsContainer.decode(LdpVpFormatSupported.self, forKey: key)
             case .mso_mdoc:
-                decodedFormats[key] = try vpFormatsContainer.decode(MsoMdocVcFormatSupported.self, forKey: key)
+                decodedFormats[key] = try vpFormatsContainer.decode(MsoMdocVpFormatSupported.self, forKey: key)
             case .dc_sd_jwt, .vc_sd_jwt:
-                decodedFormats[key] = try vpFormatsContainer.decode(SdJwtVcFormatSupported.self, forKey: key)
+                decodedFormats[key] = try vpFormatsContainer.decode(SdJwtVpFormatSupported.self, forKey: key)
             }
         }
         return decodedFormats
@@ -146,15 +146,15 @@ public struct WalletConfig: Codable {
         for (key, value) in vpFormatsSupported {
             switch key {
             case .ldp_vc, .ldp_vp:
-                if let v = value as? LdpVcFormatSupported {
+                if let v = value as? LdpVpFormatSupported {
                     try vpFormatsContainer.encode(v, forKey: key)
                 }
             case .mso_mdoc:
-                if let v = value as? MsoMdocVcFormatSupported {
+                if let v = value as? MsoMdocVpFormatSupported {
                     try vpFormatsContainer.encode(v, forKey: key)
                 }
             case .dc_sd_jwt, .vc_sd_jwt:
-                if let v = value as? SdJwtVcFormatSupported {
+                if let v = value as? SdJwtVpFormatSupported {
                     try vpFormatsContainer.encode(v, forKey: key)
                 }
             }
@@ -174,9 +174,9 @@ public struct WalletConfig: Codable {
 struct WalletConfigDefaults {
     @usableFromInline
     static let vpFormatsSupported: [VPFormatType: VPFormatSupported] = [
-        .ldp_vc: LdpVcFormatSupported(),
-        .mso_mdoc: MsoMdocVcFormatSupported(),
-        .dc_sd_jwt: SdJwtVcFormatSupported()
+        .ldp_vc: LdpVpFormatSupported(),
+        .mso_mdoc: MsoMdocVpFormatSupported(),
+        .dc_sd_jwt: SdJwtVpFormatSupported()
     ]
     
     @usableFromInline

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataTests.swift
@@ -10,7 +10,7 @@ final class ClientMetadataTests: XCTestCase {
     // MARK: - init (memberwise)
 
     func testInitStoresAllFields() {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020])
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020])
         let metadata = ClientMetadata(
             clientName: "Client",
             logoUri: "https://example.com/logo.png",
@@ -46,7 +46,7 @@ final class ClientMetadataTests: XCTestCase {
         XCTAssertEqual(decoded.encryptedResponseEncValuesSupported, ["A256GCM"])
         XCTAssertNotNil(decoded.jwks)
         XCTAssertEqual(decoded.vpFormatsSupported.count, 1)
-        XCTAssertNotNil(decoded.vpFormatsSupported["ldp_vc"] as? LdpVcFormatSupported)
+        XCTAssertNotNil(decoded.vpFormatsSupported["ldp_vc"] as? LdpVpFormatSupported)
     }
 
     func testDecodeOptionalFieldsAbsent() throws {
@@ -61,7 +61,7 @@ final class ClientMetadataTests: XCTestCase {
     func testDecodeVpFormatsSupportedLdpVc() throws {
         let data = json()
         let decoded = try JSONDecoder().decode(ClientMetadata.self, from: data)
-        let ldp = decoded.vpFormatsSupported["ldp_vc"] as? LdpVcFormatSupported
+        let ldp = decoded.vpFormatsSupported["ldp_vc"] as? LdpVpFormatSupported
         XCTAssertNotNil(ldp)
         XCTAssertEqual(ldp?.proofTypeValues, [.ed25519Signature2020])
     }
@@ -71,7 +71,7 @@ final class ClientMetadataTests: XCTestCase {
         {"ldp_vp": {"proof_type_values": ["JsonWebSignature2020"]}}
         """)
         let decoded = try JSONDecoder().decode(ClientMetadata.self, from: data)
-        XCTAssertNotNil(decoded.vpFormatsSupported["ldp_vp"] as? LdpVcFormatSupported)
+        XCTAssertNotNil(decoded.vpFormatsSupported["ldp_vp"] as? LdpVpFormatSupported)
     }
 
     func testDecodeVpFormatsSupportedMsoMdoc() throws {
@@ -79,7 +79,7 @@ final class ClientMetadataTests: XCTestCase {
         {"mso_mdoc": {"issuerauth_alg_values": [-7], "deviceauth_alg_values": [-9]}}
         """)
         let decoded = try JSONDecoder().decode(ClientMetadata.self, from: data)
-        let mdoc = decoded.vpFormatsSupported["mso_mdoc"] as? MsoMdocVcFormatSupported
+        let mdoc = decoded.vpFormatsSupported["mso_mdoc"] as? MsoMdocVpFormatSupported
         XCTAssertNotNil(mdoc)
         XCTAssertEqual(mdoc?.issuerAuthAlgValues, [-7])
         XCTAssertEqual(mdoc?.deviceAuthAlgValues, [-9])
@@ -90,7 +90,7 @@ final class ClientMetadataTests: XCTestCase {
         {"dc+sd-jwt": {"sd-jwt_alg_values": ["ES256"], "kb-jwt_alg_values": ["EdDSA"]}}
         """)
         let decoded = try JSONDecoder().decode(ClientMetadata.self, from: data)
-        let sdJwt = decoded.vpFormatsSupported["dc+sd-jwt"] as? SdJwtVcFormatSupported
+        let sdJwt = decoded.vpFormatsSupported["dc+sd-jwt"] as? SdJwtVpFormatSupported
         XCTAssertNotNil(sdJwt)
         XCTAssertEqual(sdJwt?.sdJwtAlgValues, ["ES256"])
         XCTAssertEqual(sdJwt?.kbJwtAlgValues, ["EdDSA"])
@@ -101,13 +101,13 @@ final class ClientMetadataTests: XCTestCase {
         {"vc+sd-jwt": {"sd-jwt_alg_values": ["ES256"]}}
         """)
         let decoded = try JSONDecoder().decode(ClientMetadata.self, from: data)
-        XCTAssertNotNil(decoded.vpFormatsSupported["vc+sd-jwt"] as? SdJwtVcFormatSupported)
+        XCTAssertNotNil(decoded.vpFormatsSupported["vc+sd-jwt"] as? SdJwtVpFormatSupported)
     }
 
     // MARK: - encode(to encoder)
 
     func testEncodeAndDecode() throws {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020])
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020])
         let original = ClientMetadata(
             clientName: "Client",
             logoUri: "https://example.com/logo.png",
@@ -125,7 +125,7 @@ final class ClientMetadataTests: XCTestCase {
 
     func testEncodeOmitsNilOptionalFields() throws {
         let metadata = ClientMetadata(
-            vpFormatsSupported: ["ldp_vc": LdpVcFormatSupported()]
+            vpFormatsSupported: ["ldp_vc": LdpVpFormatSupported()]
         )
         let data = try JSONEncoder().encode(metadata)
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
@@ -138,7 +138,7 @@ final class ClientMetadataTests: XCTestCase {
 
     func testEncodeVpFormatsSupportedSkipsUnknownFormatType() throws {
         let metadata = ClientMetadata(
-            vpFormatsSupported: ["unknown_format": LdpVcFormatSupported()]
+            vpFormatsSupported: ["unknown_format": LdpVpFormatSupported()]
         )
         let data = try JSONEncoder().encode(metadata)
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
@@ -147,7 +147,7 @@ final class ClientMetadataTests: XCTestCase {
     }
 
     func testEncodeVpFormatsSupportedMsoMdoc() throws {
-        let mdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
+        let mdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
         let metadata = ClientMetadata(
             vpFormatsSupported: ["mso_mdoc": mdoc]
         )
@@ -158,7 +158,7 @@ final class ClientMetadataTests: XCTestCase {
     }
 
     func testEncodeVpFormatsSupportedSdJwt() throws {
-        let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
+        let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
         let metadata = ClientMetadata(
             vpFormatsSupported: ["dc+sd-jwt": sdJwt]
         )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataUtilTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataUtilTests.swift
@@ -108,7 +108,7 @@ final class ClientMetadataUtilTests: XCTestCase {
 
     func testV1ParsingOfClientMetadataWhenAlreadyClientMetadataSpecVersion1Instance() throws {
         let clientMetadataInstance = ClientMetadata(
-            vpFormatsSupported: ["ldp_vc": LdpVcFormatSupported()]
+            vpFormatsSupported: ["ldp_vc": LdpVpFormatSupported()]
         )
         let authorizationRequest = createAuthorizationRequest(clientMetadata: clientMetadataInstance)
 

--- a/Tests/OpenID4VPTests/TestData/TestData.swift
+++ b/Tests/OpenID4VPTests/TestData/TestData.swift
@@ -278,7 +278,7 @@ let dcqlQuery = [
 let validDcqlQuery = createInstance(dcqlQuery, as: DCQLQuery.self)
 
 let vpFormatsMap: [String: VPFormatSupported] = [
-    "ldp_vc": LdpVcFormatSupported(proofTypeValues: [ .ed25519Signature2020])
+    "ldp_vc": LdpVpFormatSupported(proofTypeValues: [ .ed25519Signature2020])
 ]
 
 let clientMetadataSpecVersionDraft23: [String: Any] = [

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -282,9 +282,9 @@ func getMockAuthorizationRequest(responseMode: ResponseMode = .directPost, respo
 
 func createWalletConfig(
     vpFormatsSupported: [VPFormatType: VPFormatSupported] = [
-        .ldp_vc: LdpVcFormatSupported(),
-        .mso_mdoc: MsoMdocVcFormatSupported(),
-        .dc_sd_jwt: SdJwtVcFormatSupported()
+        .ldp_vc: LdpVpFormatSupported(),
+        .mso_mdoc: MsoMdocVpFormatSupported(),
+        .dc_sd_jwt: SdJwtVpFormatSupported()
     ],
     clientIdPrefixesSupported: [ClientIdPrefix] = [.preRegistered, .redirectUri, .decentralizedIdentifier],
     requestObjectSigningAlgValuesSupported: [SignatureAlgorithm]? = [.edDsa],

--- a/Tests/OpenID4VPTests/Wallet/VPFormatSupportedTests.swift
+++ b/Tests/OpenID4VPTests/Wallet/VPFormatSupportedTests.swift
@@ -6,13 +6,13 @@ final class VPFormatSupportedTests: XCTestCase {
     // MARK: - LdpVcFormatSupported init
 
     func testLdpVcFormatSupportedDefaultInit() {
-        let ldp = LdpVcFormatSupported()
+        let ldp = LdpVpFormatSupported()
         XCTAssertEqual(ldp.proofTypeValues, [.ed25519Signature2020, .jsonWebSignature2020])
         XCTAssertNil(ldp.cryptoSuiteValues)
     }
 
     func testLdpVcFormatSupportedCustomInit() {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: ["suite1"])
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: ["suite1"])
         XCTAssertEqual(ldp.proofTypeValues, [.ed25519Signature2020])
         XCTAssertEqual(ldp.cryptoSuiteValues, ["suite1"])
     }
@@ -23,7 +23,7 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {"proof_type_values": ["Ed25519Signature2020", "JsonWebSignature2020"]}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(LdpVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(LdpVpFormatSupported.self, from: json)
         XCTAssertEqual(decoded.proofTypeValues, [.ed25519Signature2020, .jsonWebSignature2020])
     }
 
@@ -31,7 +31,7 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {"proof_type_values": ["Ed25519Signature2020", "UnknownType", "JsonWebSignature2020"]}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(LdpVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(LdpVpFormatSupported.self, from: json)
         XCTAssertEqual(decoded.proofTypeValues, [.ed25519Signature2020, .jsonWebSignature2020])
     }
 
@@ -39,7 +39,7 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {"proof_type_values": ["UnknownType1", "UnknownType2"]}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(LdpVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(LdpVpFormatSupported.self, from: json)
         XCTAssertNil(decoded.proofTypeValues)
     }
 
@@ -47,7 +47,7 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(LdpVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(LdpVpFormatSupported.self, from: json)
         XCTAssertNil(decoded.proofTypeValues)
     }
 
@@ -55,7 +55,7 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {"proof_type_values": ["Ed25519Signature2020"], "cryptosuite_values": ["suite1", "suite2"]}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(LdpVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(LdpVpFormatSupported.self, from: json)
         XCTAssertEqual(decoded.cryptoSuiteValues, ["suite1", "suite2"])
     }
 
@@ -63,14 +63,14 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {"proof_type_values": ["Ed25519Signature2020"]}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(LdpVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(LdpVpFormatSupported.self, from: json)
         XCTAssertNil(decoded.cryptoSuiteValues)
     }
 
     // MARK: - LdpVcFormatSupported encode
 
     func testLdpVcFormatSupportedEncodesProofTypeValues() throws {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020])
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020])
         let data = try JSONEncoder().encode(ldp)
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         let proofTypes = json["proof_type_values"] as! [String]
@@ -78,14 +78,14 @@ final class VPFormatSupportedTests: XCTestCase {
     }
 
     func testLdpVcFormatSupportedEncodesCryptoSuiteValues() throws {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: ["suite1"])
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: ["suite1"])
         let data = try JSONEncoder().encode(ldp)
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         XCTAssertEqual(json["cryptosuite_values"] as! [String], ["suite1"])
     }
 
     func testLdpVcFormatSupportedOmitsCryptoSuiteValuesWhenNil() throws {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: nil)
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: nil)
         let data = try JSONEncoder().encode(ldp)
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         XCTAssertNil(json["cryptosuite_values"])
@@ -94,13 +94,13 @@ final class VPFormatSupportedTests: XCTestCase {
     // MARK: - LdpVcFormatSupported toAlgValuesSupported
 
     func testLdpVcFormatSupportedToAlgValuesSupportedReturnsRawValues() {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020, .jsonWebSignature2020])
+        let ldp = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020, .jsonWebSignature2020])
         XCTAssertEqual(ldp.toAlgValuesSupported(), ["Ed25519Signature2020", "JsonWebSignature2020"])
     }
 
     func testLdpVcFormatSupportedToAlgValuesSupportedReturnsNilWhenProofTypesNil() {
-        let ldp = LdpVcFormatSupported(proofTypeValues: [], cryptoSuiteValues: nil)
-        let ldpWithNilProofTypes = LdpVcFormatSupported(proofTypeValues: nil)
+        let ldp = LdpVpFormatSupported(proofTypeValues: [], cryptoSuiteValues: nil)
+        let ldpWithNilProofTypes = LdpVpFormatSupported(proofTypeValues: nil)
         XCTAssertNil(ldpWithNilProofTypes.toAlgValuesSupported())
         _ = ldp
     }
@@ -108,13 +108,13 @@ final class VPFormatSupportedTests: XCTestCase {
     // MARK: - MsoMdocVcFormatSupported init
 
     func testMsoMdocVcFormatSupportedDefaultInit() {
-        let mdoc = MsoMdocVcFormatSupported()
+        let mdoc = MsoMdocVpFormatSupported()
         XCTAssertNil(mdoc.issuerAuthAlgValues)
         XCTAssertNil(mdoc.deviceAuthAlgValues)
     }
 
     func testMsoMdocVcFormatSupportedCustomInit() {
-        let mdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
+        let mdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
         XCTAssertEqual(mdoc.issuerAuthAlgValues, [-7])
         XCTAssertEqual(mdoc.deviceAuthAlgValues, [-9])
     }
@@ -122,38 +122,38 @@ final class VPFormatSupportedTests: XCTestCase {
     // MARK: - MsoMdocVcFormatSupported toAlgValuesSupported
 
     func testMsoMdocVcFormatSupportedToAlgValuesSupportedMapsKnownCoseAlgs() {
-        let mdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-7, -9])
+        let mdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-7, -9])
         XCTAssertEqual(mdoc.toAlgValuesSupported(), ["ES256", "ESP256"])
     }
 
     func testMsoMdocVcFormatSupportedToAlgValuesSupportedMapsUnknownCoseAlgToLabel() {
-        let mdoc = MsoMdocVcFormatSupported(deviceAuthAlgValues: [-99])
+        let mdoc = MsoMdocVpFormatSupported(deviceAuthAlgValues: [-99])
         XCTAssertEqual(mdoc.toAlgValuesSupported(), ["Unknown(-99)"])
     }
 
     func testMsoMdocVcFormatSupportedToAlgValuesSupportedReturnsNilWhenDeviceAuthNil() {
-        let mdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: nil)
+        let mdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: nil)
         XCTAssertNil(mdoc.toAlgValuesSupported())
     }
 
     func testMsoMdocVcFormatSupportedToAlgValuesSupportedReturnsNilWhenBothNil() {
-        let mdoc = MsoMdocVcFormatSupported()
+        let mdoc = MsoMdocVpFormatSupported()
         XCTAssertNil(mdoc.toAlgValuesSupported())
     }
 
     // MARK: - MsoMdocVcFormatSupported encode / decode
 
     func testMsoMdocVcFormatSupportedEncodesAndDecodes() throws {
-        let mdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
+        let mdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
         let data = try JSONEncoder().encode(mdoc)
-        let decoded = try JSONDecoder().decode(MsoMdocVcFormatSupported.self, from: data)
+        let decoded = try JSONDecoder().decode(MsoMdocVpFormatSupported.self, from: data)
         XCTAssertEqual(decoded.issuerAuthAlgValues, [-7])
         XCTAssertEqual(decoded.deviceAuthAlgValues, [-9])
     }
 
     func testMsoMdocVcFormatSupportedDecodesNilsWhenKeysAbsent() throws {
         let json = "{}".data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(MsoMdocVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(MsoMdocVpFormatSupported.self, from: json)
         XCTAssertNil(decoded.issuerAuthAlgValues)
         XCTAssertNil(decoded.deviceAuthAlgValues)
     }
@@ -161,13 +161,13 @@ final class VPFormatSupportedTests: XCTestCase {
     // MARK: - SdJwtVcFormatSupported init
 
     func testSdJwtVcFormatSupportedDefaultInit() {
-        let sdJwt = SdJwtVcFormatSupported()
+        let sdJwt = SdJwtVpFormatSupported()
         XCTAssertNil(sdJwt.sdJwtAlgValues)
         XCTAssertNil(sdJwt.kbJwtAlgValues)
     }
 
     func testSdJwtVcFormatSupportedCustomInit() {
-        let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
+        let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
         XCTAssertEqual(sdJwt.sdJwtAlgValues, ["ES256"])
         XCTAssertEqual(sdJwt.kbJwtAlgValues, ["EdDSA"])
     }
@@ -175,33 +175,33 @@ final class VPFormatSupportedTests: XCTestCase {
     // MARK: - SdJwtVcFormatSupported toAlgValuesSupported
 
     func testSdJwtVcFormatSupportedToAlgValuesSupportedReturnsKbJwtAlgValues() {
-        let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
+        let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
         XCTAssertEqual(sdJwt.toAlgValuesSupported(), ["EdDSA"])
     }
 
     func testSdJwtVcFormatSupportedToAlgValuesSupportedReturnsNilWhenKbJwtNil() {
-        let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: nil)
+        let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: nil)
         XCTAssertNil(sdJwt.toAlgValuesSupported())
     }
 
     func testSdJwtVcFormatSupportedToAlgValuesSupportedIgnoresSdJwtAlgValues() {
-        let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: nil)
+        let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: nil)
         XCTAssertNil(sdJwt.toAlgValuesSupported())
     }
 
     // MARK: - SdJwtVcFormatSupported encode / decode
 
     func testSdJwtVcFormatSupportedEncodesAndDecodes() throws {
-        let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
+        let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["EdDSA"])
         let data = try JSONEncoder().encode(sdJwt)
-        let decoded = try JSONDecoder().decode(SdJwtVcFormatSupported.self, from: data)
+        let decoded = try JSONDecoder().decode(SdJwtVpFormatSupported.self, from: data)
         XCTAssertEqual(decoded.sdJwtAlgValues, ["ES256"])
         XCTAssertEqual(decoded.kbJwtAlgValues, ["EdDSA"])
     }
 
     func testSdJwtVcFormatSupportedDecodesNilsWhenKeysAbsent() throws {
         let json = "{}".data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(SdJwtVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(SdJwtVpFormatSupported.self, from: json)
         XCTAssertNil(decoded.sdJwtAlgValues)
         XCTAssertNil(decoded.kbJwtAlgValues)
     }
@@ -210,7 +210,7 @@ final class VPFormatSupportedTests: XCTestCase {
         let json = """
         {"sd-jwt_alg_values": ["ES256"], "kb-jwt_alg_values": ["EdDSA"]}
         """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(SdJwtVcFormatSupported.self, from: json)
+        let decoded = try JSONDecoder().decode(SdJwtVpFormatSupported.self, from: json)
         XCTAssertEqual(decoded.sdJwtAlgValues, ["ES256"])
         XCTAssertEqual(decoded.kbJwtAlgValues, ["EdDSA"])
     }

--- a/Tests/OpenID4VPTests/Wallet/WalletConfigTests.swift
+++ b/Tests/OpenID4VPTests/Wallet/WalletConfigTests.swift
@@ -5,9 +5,9 @@ final class WalletConfigTests: XCTestCase {
 
     // MARK: - Fixtures
 
-    private let ldpVc = LdpVcFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: nil)
-    private let msoMdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
-    private let sdJwt = SdJwtVcFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["ES256"])
+    private let ldpVc = LdpVpFormatSupported(proofTypeValues: [.ed25519Signature2020], cryptoSuiteValues: nil)
+    private let msoMdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: [-7], deviceAuthAlgValues: [-9])
+    private let sdJwt = SdJwtVpFormatSupported(sdJwtAlgValues: ["ES256"], kbJwtAlgValues: ["ES256"])
 
     private func makeConfig(
         vpFormats: [VPFormatType: VPFormatSupported]? = nil,
@@ -516,7 +516,7 @@ final class WalletConfigTests: XCTestCase {
     }
 
     func testToWalletMetadataDraft23VpFormatsEmptyDictWhenNoAlgValues() throws {
-        let emptyMsoMdoc = MsoMdocVcFormatSupported(issuerAuthAlgValues: nil, deviceAuthAlgValues: nil)
+        let emptyMsoMdoc = MsoMdocVpFormatSupported(issuerAuthAlgValues: nil, deviceAuthAlgValues: nil)
         let metadata = try makeConfig(vpFormats: [.mso_mdoc: emptyMsoMdoc]).toWalletMetadata(specVersion: .draft23)
         let vpFormats = try XCTUnwrap(metadata[MetadataConstants.vpFormatsSupported] as? [String: Any])
         let msoFormat = try XCTUnwrap(vpFormats["mso_mdoc"] as? [String: Any])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected format type handling for Verifiable Presentations to use VP-specific format types instead of VC types across client metadata, wallet configuration, and format support structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->