### PR TITLE
fix(authorization-request): URI validation, response_uri/redirect_uri and nonce handling

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -242,12 +242,11 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         if authorizationRequestParameters[AuthorizationRequestFieldConstants.transactionData] != nil {
             throw InvalidTransactionData(message: "Invalid Request: transaction_data is not supported in the authorization request", className: className)
         }
-        let mandatoryFields = [AuthorizationRequestFieldConstants.responseType,AuthorizationRequestFieldConstants.nonce]
-        
-        for field in mandatoryFields {
-            try validateAttribute(field, values: authorizationRequestParameters)
-        }
-        
+        try validateAttribute(AuthorizationRequestFieldConstants.responseType, values: authorizationRequestParameters)
+
+        // missing nonce is not notified to the verifier
+        try validateAttribute(AuthorizationRequestFieldConstants.nonce, values: authorizationRequestParameters, notifyVerifier: false)
+
         try validateResponseTypeSupported((authorizationRequestParameters[AuthorizationRequestFieldConstants.responseType] as? String)!)
         
         let optionalFields = [AuthorizationRequestFieldConstants.state, AuthorizationRequestFieldConstants.responseMode]

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -264,7 +264,17 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
     
     final func setResponseUrl() throws {
         let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
-        
+
+        // redirect_uri must not be present for direct_post / direct_post.jwt
+        if responseMode == ResponseMode.directPost.rawValue || responseMode == ResponseMode.directPostJwt.rawValue {
+            if authorizationRequestParameters.keys.contains(AuthorizationRequestFieldConstants.redirectUri) {
+                throw InvalidData(
+                    message: "\(AuthorizationRequestFieldConstants.redirectUri) should not be present for given response_mode",
+                    className: className
+                )
+            }
+        }
+
         try ResponseModeBasedHandlerFactory.get(responseMode: responseMode).setResponseUrl(authorizationRequestParameters: authorizationRequestParameters,setResponseUri: setResponseUri)
     }
     

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
@@ -43,7 +43,7 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
         let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
         switch responseMode {
         case ResponseMode.directPost.rawValue, ResponseMode.directPostJwt.rawValue:
-            try validateUriCombinations(authorizationRequestParameters: authorizationRequestParameters, validAttribute: AuthorizationRequestFieldConstants.responseUri, inValidAttribute: AuthorizationRequestFieldConstants.redirectUri)
+            try validateResponseUriMatchesClientId(authorizationRequestParameters: authorizationRequestParameters)
             break
         case ResponseMode.iarPost.rawValue, ResponseMode.iarPostJwt.rawValue:
             print("IAR_POST or IAR_POST_JWT response_mode is used")
@@ -53,22 +53,18 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
                 className: className
             )
         }
-        
+
     }
-    
-    private func validateUriCombinations(authorizationRequestParameters: [String: Any], validAttribute: String, inValidAttribute: String) throws {
-        if authorizationRequestParameters.keys.contains(inValidAttribute) {
-            throw InvalidData(message: "\(inValidAttribute) should not be present for given response_mode", className: className)
-        } else {
-            try validateAttribute(validAttribute, values: self.authorizationRequestParameters)
-        }
-        
-        let validValue = authorizationRequestParameters[validAttribute]
+
+    private func validateResponseUriMatchesClientId(authorizationRequestParameters: [String: Any]) throws {
+        try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: self.authorizationRequestParameters)
+
+        let responseUriValue = authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri]
         let clientIdValue = extractClientIdPartOnly(authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as? String ?? "")
-        
-        if validValue as? String != clientIdValue {
+
+        if responseUriValue as? String != clientIdValue {
             throw InvalidData(
-                message: "\(validAttribute) should be equal to client_id for given client_id_prefix",
+                message: "\(AuthorizationRequestFieldConstants.responseUri) should be equal to client_id for given client_id_prefix",
                 className: className
             )
         }

--- a/Sources/OpenID4VP/AuthorizationRequest/Utils/AuthorizationRequestUtils.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/Utils/AuthorizationRequestUtils.swift
@@ -3,22 +3,25 @@ import CryptoKit
 
 func validateAttribute(
     _ attribute: String,
-    values: [String: Any]
+    values: [String: Any],
+    notifyVerifier: Bool = true
 ) throws {
     guard let value = values[attribute] else {
         throw MissingInput(
             fieldPath: [attribute],
-            className: AuthorizationRequest.className
+            className: AuthorizationRequest.className,
+            notifyVerifier: notifyVerifier
         )
     }
-    
+
     if let stringValue = value as? String {
         if stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
             stringValue.lowercased() == "nil" ||
             stringValue.lowercased() == "null" {
             throw InvalidInput(
                 fieldPath: [attribute],
-                className: AuthorizationRequest.className
+                className: AuthorizationRequest.className,
+                notifyVerifier: notifyVerifier
             )
         }
     }

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -33,10 +33,18 @@ func getStringValue(_ value: Any?) -> String? {
     return value as? String
 }
 
+// RFC 3986 (https://www.rfc-editor.org/rfc/rfc3986#section-3) https URI, compiled once
+private let urlValidationRegex: NSRegularExpression? = {
+    let pattern = #"^https://(?:[\w-]+\.)+[\w-]+(?::\d+)?(?:/(?:[\w\-.~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})*)*(?:\?(?:[\w\-.~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*)?(?:#(?:[\w\-.~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*)?$"#
+    return try? NSRegularExpression(pattern: pattern)
+}()
+
 public func isValidUri(_ urlString: String) -> Bool {
-    let urlRegex = #"^https:\/\/(?:[\w-]+\.)+[\w-]+(?:\/[\w\-.~!$&'()*+,;=:@%]+)*\/?(?:\?[^#\s]*)?(?:#.*)?$"#
-    
-    return urlString.range(of: urlRegex, options: .regularExpression) != nil
+    guard let regex = urlValidationRegex else { return false }
+    let range = NSRange(urlString.startIndex..., in: urlString)
+    guard let match = regex.firstMatch(in: urlString, options: [], range: range) else { return false }
+    // require the match to span the whole string (ICU's `$` allows a trailing newline)
+    return match.range == range
 }
 
 func convertToInstance<T: Decodable>(_ dictionary: [String: Any], as type: T.Type) throws -> T {

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -8,7 +8,9 @@ public class OpenID4VPException: Error, CustomStringConvertible, LocalizedError 
     public let cause: Error?
     // holds the response received from the Verifier if the error is sent to the Verifier
     public var verifierResponse: VerifierResponse?
-    
+    // whether this error should be dispatched to the Verifier; defaults to true
+    public let notifyVerifier: Bool
+
     internal func setVerifierResponse(_ response: VerifierResponse) {
         self.verifierResponse = response
     }
@@ -16,11 +18,12 @@ public class OpenID4VPException: Error, CustomStringConvertible, LocalizedError 
     private static var logTag = ""
     private static var traceabilityId: String?
 
-    public init(errorCode: String, message: String, cause: Error? = nil, className: String) {
+    public init(errorCode: String, message: String, cause: Error? = nil, className: String, notifyVerifier: Bool = true) {
         self.errorCode = errorCode
         self.message = message
         self.className = className
         self.cause = cause
+        self.notifyVerifier = notifyVerifier
         print("ERROR [\(errorCode)] - \(message) | Class: \(className)")
     }
 
@@ -139,7 +142,7 @@ class InvalidData: OpenID4VPException {
 }
 
 class MissingInput: OpenID4VPException {
-    init(fieldPath: Any, message: String? = "", className: String) {
+    init(fieldPath: Any, message: String? = "", className: String, notifyVerifier: Bool = true) {
         let resolvedMessage: String
         if let field = fieldPath as? String, !field.isEmpty {
             resolvedMessage = "Missing Input: \(field) param is required"
@@ -148,12 +151,12 @@ class MissingInput: OpenID4VPException {
         } else {
             resolvedMessage = message ?? ""
         }
-        super.init(errorCode: OpenID4VPErrorCodes.invalidRequest, message: resolvedMessage, className: className)
+        super.init(errorCode: OpenID4VPErrorCodes.invalidRequest, message: resolvedMessage, className: className, notifyVerifier: notifyVerifier)
     }
 }
 
 class InvalidInput: OpenID4VPException {
-    init(fieldPath: Any, value: Any? = nil, className: String) {
+    init(fieldPath: Any, value: Any? = nil, className: String, notifyVerifier: Bool = true) {
         let path = (fieldPath as? [String])?.joined(separator: "->") ?? "\(fieldPath)"
         let message: String
 
@@ -167,7 +170,7 @@ class InvalidInput: OpenID4VPException {
             message = "Invalid Input: \(path) value is invalid"
         }
 
-        super.init(errorCode: OpenID4VPErrorCodes.invalidRequest, message: message, className: className)
+        super.init(errorCode: OpenID4VPErrorCodes.invalidRequest, message: message, className: className, notifyVerifier: notifyVerifier)
     }
 }
 

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -154,6 +154,7 @@ public class OpenID4VP {
     }
 
     private func safeSendError(error: Error) async {
+        if let exception = error as? OpenID4VPException, !exception.notifyVerifier { return }
         do {
             let verifierResponse = try await sendErrorInfoToVerifier(error: error)
             (error as? OpenID4VPException)?.setVerifierResponse(verifierResponse)

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
@@ -52,8 +52,22 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         }
     }
     
+    func testThrowErrorWhenBothResponseUriAndRedirectUriPresentForDirectPost() {
+        var authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
+        authorizationRequestParameters[AuthorizationRequestFieldConstants.redirectUri] = "https://mock-verifier.com"
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+
+        XCTAssertThrowsError(try preRegistered.setResponseUrl()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "redirect_uri should not be present for given response_mode",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
     // Support for Authorization request by reference or by value
-    
+
     func testReturnTrueForAuthorizationRequestByReferenceSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
@@ -58,6 +58,19 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         }
     }
     
+    func testThrowErrorWhenBothResponseUriAndRedirectUriPresentForDirectPost() {
+        var authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter), addEncryptionClientMetadataParams: false) as [String : Any]
+        authorizationRequestParameters[AuthorizationRequestFieldConstants.redirectUri] = "https://mock-verifier.com"
+        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+
+        XCTAssertThrowsError(try redirectUriSchemeAuthRequestHandler.setResponseUrl()) { error in
+            assertOpenID4VPException(error,
+                                     expectedMessage: "redirect_uri should not be present for given response_mode",
+                                     expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
     func testThrowErrorWhenAuthorizationRequestObjectClientIdIsNotMatchingWithRequestParameterClientIdInDirectPostResponseMode() async {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter, [AuthorizationRequestFieldConstants.responseMode: "fragment","redirect_uri": "http://invalid-mock-verifier.com"])) as [String : Any]
         let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)

--- a/Tests/OpenID4VPTests/Common/UtilsTest.swift
+++ b/Tests/OpenID4VPTests/Common/UtilsTest.swift
@@ -23,27 +23,40 @@ class UtilsTest : XCTestCase {
     /// Validate url tests
     
     func testInvalidUrl() {
-        let testCases: [TestCase] = [
-            TestCase(input: "www.example.com"),
-            TestCase(input: "http://example.com/space here"),
-            TestCase(input: "http://"),
-            TestCase(input: "https://example"),
-            TestCase(input: "http://example.com/file%/name"),
-            TestCase(input: "http://example.com:99999"),
-            TestCase(input: "http:///example.com"),
-            TestCase(input: "http://example.com/search?q=hello%20world#@fragment"),
-            TestCase(input: "http://:8080"),
-            TestCase(input: ""),
-            TestCase(input: "https://example.com/invalid|character")
+        let invalidUrls: [String] = [
+            "www.example.com",
+            "http://example.com/space here",
+            "http://",
+            "https://example",
+            "http://example.com/file%/name",
+            "http://example.com:99999",
+            "http:///example.com",
+            "http://example.com/search?q=hello%20world#@fragment",
+            "http://:8080",
+            "",
+            "https://example.com/invalid|character",
+            "foo://example.com:8042/over/there?name=ferret#nose",
+            "https://example.com/file%/name",
+            "https://example.com/space here",
+            "https://example.com/path\n"
         ]
-        
-        for testCase in testCases {
-            XCTAssertFalse(isValidUri(testCase.input))
+
+        for url in invalidUrls {
+            XCTAssertFalse(isValidUri(url), "expected invalid: \(url)")
         }
     }
-    
+
     func testValidUrl(){
-        XCTAssertTrue(isValidUri("https://609e-122-178-244-112.ngrok-free.app/verifier/get-auth-request-obj/did?draft=version-1.0&response_mode=direct_post"))
+        let validUrls: [String] = [
+            "https://609e-122-178-244-112.ngrok-free.app/verifier/get-auth-request-obj/did?draft=version-1.0&response_mode=direct_post",
+            "https://example.com:8042/over/there?name=ferret#nose",
+            "https://example.com/a%20b?q=hello%20world",
+            "https://example.com//empty/seg",
+            "https://example.com/p?a=1/2&b=x?y#f/g?h"
+        ]
+        for url in validUrls {
+            XCTAssertTrue(isValidUri(url), "expected valid: \(url)")
+        }
     }
     
     /// Check if input is JWT tests

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -107,6 +107,37 @@ class OpenID4VPTests: XCTestCase {
         }
     }
 
+    // Missing nonce must NOT trigger a verifier notification
+    func testAuthenticateVerifierDoesNotNotifyVerifierWhenNonceIsMissing() async {
+        let requestWithoutNonce = createUrlEncodedAuthorizationRequest(
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter),
+            clientIdPrefix: .redirectUri,
+            applicableFields: authRequestWithRedirectUriByValue.filter { $0 != "nonce" },
+            addEncryptionClientMetadataParams: false
+        )
+
+        let result = await Task {
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: requestWithoutNonce)
+        }.result
+
+        switch result {
+        case let .failure(error):
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Missing Input: nonce param is required",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        case .success:
+            XCTFail("Expected error for missing nonce but got success")
+        }
+
+        // No error POST should have been dispatched to the verifier's response_uri
+        XCTAssertTrue(
+            mockNetworkManager.recordedRequests.isEmpty,
+            "Verifier should not be notified when nonce is missing"
+        )
+    }
+
     // client_id_prefix = pre-registered
     func testReturnDataForValidRequestWithResponseUri() async {
         let requestUriResponse = createAuthorizationRequestObject(clientIdPrefix: .preRegistered, authorizationRequestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters), applicableFields: authRequestWithPreRegisteredByValue)


### PR DESCRIPTION
Validates request/response/presentation-definition URIs against an RFC 3986 https pattern, rejects requests carrying both response_uri and redirect_uri for direct_post / direct_post.jwt across all client_id_prefixes, and skips notifying the Verifier when nonce is missing.



## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for `direct_post` and `direct_post.jwt` response modes to properly enforce that `redirect_uri` must not be present alongside `response_uri`.
  * Improved `nonce` field validation to prevent unnecessary verifier notifications when validation fails.
  * Strengthened HTTPS URL validation to prevent partial regex matches and enforce RFC 3986 compliance.

* **Tests**
  * Added comprehensive test coverage for `direct_post` response mode parameter validation.
  * Added test case verifying proper error handling when required fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->