### PR TITLE
revert: remove iae_post and iae_post.jwt response mode support

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
@@ -45,13 +45,8 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
         case ResponseMode.directPost.rawValue, ResponseMode.directPostJwt.rawValue:
             try validateResponseUriMatchesClientId(authorizationRequestParameters: authorizationRequestParameters)
             break
-            
-        case ResponseMode.iarPost.rawValue,
-             ResponseMode.iarPostJwt.rawValue,
-             ResponseMode.iaePost.rawValue,
-             ResponseMode.iaePostJwt.rawValue:
-            break
-           
+        case ResponseMode.iarPost.rawValue, ResponseMode.iarPostJwt.rawValue:
+            print("IAR_POST or IAR_POST_JWT response_mode is used")
         default:
             throw InvalidResponseMode(
                 message : "Given response_mode \(String(describing: responseMode)) is not supported",

--- a/Sources/OpenID4VP/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtil.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtil.swift
@@ -141,13 +141,9 @@ func parseAndValidatePresentationDefinition(
 fileprivate func validateForCredentialFormat(_ presentationDefinition: PresentationDefinition, responseMode: String?) throws {
     //In case of mso_mdoc format VCs requested in Authorization Request, direct_post.jwt is the allowed response_mode
     let hasMsoMdocFormat: Bool =  presentationDefinition.format?.contains(where: { $0.key == FormatType.mso_mdoc.rawValue }) ?? false || presentationDefinition.inputDescriptors.contains(where: {$0.format?.contains(where: { $0.key == FormatType.mso_mdoc.rawValue }) ?? false})
-    if hasMsoMdocFormat &&
-       (responseMode != ResponseMode.directPostJwt.rawValue &&
-        responseMode != ResponseMode.iarPostJwt.rawValue &&
-        responseMode != ResponseMode.iaePostJwt.rawValue) {
-
+    if(hasMsoMdocFormat && (responseMode != ResponseMode.directPostJwt.rawValue && responseMode != ResponseMode.iarPostJwt.rawValue)){
         throw InvalidData(
-            message: "When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt, iar-post.jwt or iae_post.jwt",
+            message: "When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt or iar_post.jwt",
             className: className
         )
     }

--- a/Sources/OpenID4VP/Constants/ResponseMode.swift
+++ b/Sources/OpenID4VP/Constants/ResponseMode.swift
@@ -3,12 +3,6 @@ import Foundation
 public enum ResponseMode: String {
     case directPost = "direct_post"
     case directPostJwt = "direct_post.jwt"
-
-    // Backward compatible response modes
     case iarPost = "iar-post"
     case iarPostJwt = "iar-post.jwt"
-
-    // OpenID4VCI 1.1 (IAE)
-    case iaePost = "iae_post"
-    case iaePostJwt = "iae_post.jwt"
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandlerFactory.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandlerFactory.swift
@@ -5,22 +5,16 @@ struct ResponseModeBasedHandlerFactory {
     
     static func get(responseMode: String?) throws -> ResponseModeBasedHandler {
         switch responseMode {
-        case ResponseMode.directPost.rawValue,
-             ResponseMode.iarPost.rawValue,
-             ResponseMode.iaePost.rawValue:
+        case ResponseMode.directPost.rawValue, ResponseMode.iarPost.rawValue:
             return DirectPostResponseModeHandler()
-
-        case ResponseMode.directPostJwt.rawValue,
-             ResponseMode.iarPostJwt.rawValue,
-             ResponseMode.iaePostJwt.rawValue:
+        case ResponseMode.directPostJwt.rawValue, ResponseMode.iarPostJwt.rawValue:
             return DirectPostJwtResponseModeHandler()
-
         default:
             throw InvalidData(
-                message: "Given response_mode - \(responseMode ?? "") is not supported",
-                className: className,
-                code: OpenID4VPErrorCodes.invalidRequest
-            )
+                            message: "Given response_mode - \(responseMode ?? "") is not supported",
+                            className: className,
+                            code: OpenID4VPErrorCodes.invalidRequest
+                        )
         }
     }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
@@ -185,44 +185,6 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
 
         await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
     }
-    
-    func testValidateAndParseRequestFieldsSucceedsWithIaeResponseModes() async {
-
-        let testCases = [
-            ("iae_post", false),
-            ("iae_post.jwt", true)
-        ]
-
-        for (responseMode, addEncryptionMetadata) in testCases {
-
-            let params = createAuthorizationRequest(
-                paramList: authRequestWithRedirectUriByValue,
-                requestParams: mergeMaps(
-                    authorizationRequestParamsWithValue,
-                    redirectUriSchemeClientIdParameter,
-                    [
-                        "response_mode": responseMode,
-                        "response_uri": "https://mock-verifier.com/redirect"
-                    ]
-                ),
-                addEncryptionClientMetadataParams: addEncryptionMetadata
-            ) as [String : Any]
-
-            let handler = RedirectUriPrefixAuthorizationRequestHandler(
-                clientId: clientId,
-                specVersion: .v1,
-                authorizationRequestParameters: params,
-                walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
-                walletNonce: "mock-nonce",
-                networkManager: mockNetworkManager
-            )
-
-            await XCTAssertAsyncNoThrowsError(
-                try await handler.validateAndParseRequestFields()
-            )
-        }
-    }
 
     func testValidateAndParseRequestFieldsSucceedsWithIarPostJwtResponseMode() async {
         let params = createAuthorizationRequest(
@@ -247,7 +209,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
 
         await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
     }
-    
+
     func testValidateAndParseRequestFieldsSucceedsWithIarPostWithoutResponseUri() async {
         let params = createAuthorizationRequest(
             paramList: authRequestWithRedirectUriByValue,
@@ -270,7 +232,6 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
     }
 
-
     func testValidateAndParseRequestFieldsSucceedsWithIarPostJwt_WithoutResponseUri() async {
         let params = createAuthorizationRequest(
             paramList: authRequestWithRedirectUriByValue,
@@ -290,42 +251,6 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         )
 
         await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
-    }
-
-    
-    func testValidateAndParseRequestFieldsSucceedsWithIaeResponseModesWithoutResponseUri() async {
-
-        let testCases: [(responseMode: String, addEncryptionMetadata: Bool)] = [
-            ("iae_post", false),
-            ("iae_post.jwt", true)
-        ]
-
-        for testCase in testCases {
-
-            let params = createAuthorizationRequest(
-                paramList: authRequestWithRedirectUriByValue,
-                requestParams: mergeMaps(
-                    authorizationRequestParamsWithValue,
-                    redirectUriSchemeClientIdParameter,
-                    ["response_mode": testCase.responseMode]
-                ),
-                addEncryptionClientMetadataParams: testCase.addEncryptionMetadata
-            ) as [String : Any]
-
-            let handler = RedirectUriPrefixAuthorizationRequestHandler(
-                clientId: clientId,
-                specVersion: .v1,
-                authorizationRequestParameters: params,
-                walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
-                walletNonce: "mock-nonce",
-                networkManager: mockNetworkManager
-            )
-
-            await XCTAssertAsyncNoThrowsError(
-                try await handler.validateAndParseRequestFields()
-            )
-        }
     }
 
     func testValidateAndParseRequestFieldsSucceedsWithIarPostMismatchedResponseUri() async {
@@ -353,7 +278,6 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
     }
 
-
     func testValidateAndParseRequestFieldsSucceedsWithIarPostJwtMismatchedResponseUri() async {
         let params = createAuthorizationRequest(
             paramList: authRequestWithRedirectUriByValue,
@@ -378,42 +302,4 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
     }
 
-    
-    func testValidateAndParseRequestFieldsSucceedsWithIaeMismatchedResponseUri() async {
-
-        let testCases: [(responseMode: String, addEncryptionMetadata: Bool)] = [
-            ("iae_post", false),
-            ("iae_post.jwt", true)
-        ]
-
-        for testCase in testCases {
-
-            let params = createAuthorizationRequest(
-                paramList: authRequestWithRedirectUriByValue,
-                requestParams: mergeMaps(
-                    authorizationRequestParamsWithValue,
-                    redirectUriSchemeClientIdParameter,
-                    [
-                        "response_mode": testCase.responseMode,
-                        "response_uri": "https://different.com/response"
-                    ]
-                ),
-                addEncryptionClientMetadataParams: testCase.addEncryptionMetadata
-            ) as [String : Any]
-
-            let handler = RedirectUriPrefixAuthorizationRequestHandler(
-                clientId: clientId,
-                specVersion: .v1,
-                authorizationRequestParameters: params,
-                walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
-                walletNonce: "mock-nonce",
-                networkManager: mockNetworkManager
-            )
-
-            await XCTAssertAsyncNoThrowsError(
-                try await handler.validateAndParseRequestFields()
-            )
-        }
-    }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtilTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/PresentationDefinition/PresentationDefinitionUtilTests.swift
@@ -93,7 +93,7 @@ final class PresentationDefinitionUtilTests: XCTestCase {
         for testCase in testCases {
             await XCTAssertAsyncThrowsError(try await parseAndValidatePresentationDefinition(testCase.input, isPresentationDefinitionUriSupported, networkManager)) { error in
                 assertOpenID4VPException(error,
-                expectedMessage: "When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt, iar-post.jwt or iae_post.jwt",
+                    expectedMessage: "When mso_mdoc format is present in presentation definition, response_mode must be direct_post.jwt or iar_post.jwt",
                     expectedCode: OpenID4VPErrorCodes.invalidRequest
                 )
             }

--- a/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedLdpVPTokenBuilderTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/UnsignedVPToken/UnsignedLdpVPTokenBuilderTests.swift
@@ -294,7 +294,7 @@ final class UnsignedLdpVPTokenBuilderTests: XCTestCase {
         ]
 
         let (payload, unsignedVPTokens) = try await builder.build(credentialToCredentialQueryIdMappings: &mappings)
-        
+
         XCTAssertEqual(unsignedVPTokens.count, 0)
         assertLdpVPTokenPayload(payload, expectedCredentialsInPresentation: convertToJsonString([ldpVC()]), tokenType: .vc)
     }
@@ -567,7 +567,7 @@ final class UnsignedLdpVPTokenBuilderTests: XCTestCase {
                 XCTFail("Expected [String: LdpVP] payload with LdpVP.vc entries for VC type", file: file, line: line)
                 return
             }
-            assertJsonString(expected: expectedCredentialsInPresentation, actual: convertToJsonString([ldpVCToken.verifiableCredential.value]), file: file, line: line)
+            assertJsonString(expected: expectedCredentialsInPresentation, actual: convertToJsonString([ldpVCToken.verifiableCredential]), file: file, line: line)
         }
     }
 

--- a/Tests/OpenID4VPTests/ResponseModeHandler/ResponseModeBasedHandlerFactoryTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/ResponseModeBasedHandlerFactoryTests.swift
@@ -17,15 +17,11 @@ final class ResponseModeBasedHandlerFactoryTests: XCTestCase {
         let responseModeHandler2: any ResponseModeBasedHandler = try ResponseModeBasedHandlerFactory.get(responseMode: "direct_post.jwt")
         let responseModeHandler3: any ResponseModeBasedHandler = try ResponseModeBasedHandlerFactory.get(responseMode: "iar-post")
         let responseModeHandler4: any ResponseModeBasedHandler = try ResponseModeBasedHandlerFactory.get(responseMode: "iar-post.jwt")
-        let responseModeHandler5: any ResponseModeBasedHandler = try ResponseModeBasedHandlerFactory.get(responseMode: "iae_post")
-        let responseModeHandler6: any ResponseModeBasedHandler = try ResponseModeBasedHandlerFactory.get(responseMode: "iae_post.jwt")
         
         XCTAssertTrue(responseModeHandler1 is DirectPostResponseModeHandler)
         XCTAssertTrue(responseModeHandler2 is DirectPostJwtResponseModeHandler)
         XCTAssertTrue(responseModeHandler3 is DirectPostResponseModeHandler)
         XCTAssertTrue(responseModeHandler4 is DirectPostJwtResponseModeHandler)
-        XCTAssertTrue(responseModeHandler5 is DirectPostResponseModeHandler)
-        XCTAssertTrue(responseModeHandler6 is DirectPostJwtResponseModeHandler)
     }
     
     func testShouldThrowErrorForEmptyResponseMode() {


### PR DESCRIPTION
Reverts the IAE response mode support (#123) from `release-1.0.x`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened response mode handling to accept only the supported `direct_post` and `iar_post` variants.
  * Requests using older `iae_*` response modes now fail validation instead of being treated as valid.
  * Improved validation for credential formats so unsupported response modes are rejected with clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->