### PR TITLE
fix: avoid notifying verifier when redirect_uri client ID and response_uri validation fails

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -8,7 +8,8 @@ protocol AbstractMethodsForClientIdPrefixBasedAuthorizationRequestHandler {
     func extractPublicKey(keyId: String?, algorithm: String) async throws -> PublicKeyType
     func clientIdPrefix() -> String
     func confirmSpecVersionIdentifiedFromRequest() -> Bool
-    // Validate if the Client is Valid or Some issues occur. This focuses on checking if a Client Posing as Say Pre-registered is actually pre-registered
+    /// Validates the authenticity of the client identifier.
+    /// For example, ensures that a client claiming to use a specific prefix is actually authorized or trusted.
     func validateClientAuthenticity() throws
 }
 

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -8,12 +8,16 @@ protocol AbstractMethodsForClientIdPrefixBasedAuthorizationRequestHandler {
     func extractPublicKey(keyId: String?, algorithm: String) async throws -> PublicKeyType
     func clientIdPrefix() -> String
     func confirmSpecVersionIdentifiedFromRequest() -> Bool
+    // Validate if the Client is Valid or Some issues occur. This focuses on checking if a Client Posing as Say Pre-registered is actually pre-registered
+    func validateClientAuthenticity() throws
 }
 
 extension AbstractMethodsForClientIdPrefixBasedAuthorizationRequestHandler {
     func confirmSpecVersionIdentifiedFromRequest() -> Bool {
         return true
     }
+    
+    func validateClientAuthenticity() throws {}
 }
 
 class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
@@ -54,6 +58,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
     func handle() async throws -> AuthorizationRequest {
         try self.validateClientId()
         try await self.fetchAuthorizationRequest()
+        try delegate.validateClientAuthenticity()
         try self.setResponseUrl()
         try await self.validateAndParseRequestFields()
         return self.createAuthorizationRequest()

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
@@ -71,7 +71,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
         }
     }
     
-    override func validateAndParseRequestFields() async throws {
+    func validateClientAuthenticity() throws {
         if walletConfig.validateTrustedVerifier {
             let clientId = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as! String
             let preRegisteredClient = try verifier(clientId: clientId)
@@ -85,7 +85,6 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
             }
             
         }
-        try await super.validateAndParseRequestFields()
     }
     
     private func filterAndExtractKey(jwks publicKeys: JWKSet, keyId: String?, algorithm: String) throws -> JWK {

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
@@ -72,7 +72,9 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
         if walletConfig.validateTrustedVerifier {
             let preRegisteredClient = try verifier(clientId: super.clientId)
             
-            let responseUri = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri]) ?? "null"
+            guard let responseUri = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri]) else {
+                throw MissingInput(fieldPath: "response_uri", className: className, notifyVerifier: false)
+            }
             guard preRegisteredClient.responseUris.contains(responseUri) else {
                 throw InvalidVerifier(
                     message: "response_uri trust cannot be established",

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
@@ -27,7 +27,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
     
     override func validateClientId() throws {
         if walletConfig.validateTrustedVerifier {
-            guard walletConfig.trustedVerifiers.contains(where: { $0.clientId == authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as? String }) else {
+            guard walletConfig.trustedVerifiers.contains(where: { $0.clientId == super.clientId }) else {
                 throw InvalidVerifier(message: "Verifier is not trusted by the wallet", className: className)
             }
         }
@@ -46,17 +46,14 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
     
     func isUnsignedRequestSupported() throws -> Bool {
         if walletConfig.validateTrustedVerifier {
-            let clientId = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId]) ?? ""
-            let preRegisteredVerifier = try verifier(clientId: clientId)
+            let preRegisteredVerifier = try verifier(clientId: super.clientId)
             return preRegisteredVerifier.allowUnsignedRequest
         }
         return true
     }
     
     func extractPublicKey(keyId: String?, algorithm: String) async throws -> PublicKeyType {
-        let clientId = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as? String
-        
-        let preRegisteredClient = try verifier(clientId: clientId ?? "")
+        let preRegisteredClient = try verifier(clientId: super.clientId)
         if let jwksUri = preRegisteredClient.jwksUri {
             let jwkSet : JWKSet = try await resolveJwksFromUri(jwksUri, networkManager: self.networkManager, className: className)
             
@@ -73,8 +70,7 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
     
     func validateClientAuthenticity() throws {
         if walletConfig.validateTrustedVerifier {
-            let clientId = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientId] as! String
-            let preRegisteredClient = try verifier(clientId: clientId)
+            let preRegisteredClient = try verifier(clientId: super.clientId)
             
             let responseUri = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri]) ?? "null"
             guard preRegisteredClient.responseUris.contains(responseUri) else {

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
@@ -37,9 +37,8 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
     func getWalletMetadata(walletConfig: WalletConfig) throws -> [String: Any] {
         return try walletConfig.toWalletMetadata(specVersion: specVersion, excludeSignedRequestConfig: true)
     }
-
-    override func validateAndParseRequestFields()async throws {
-        try await super.validateAndParseRequestFields()
+    
+    func validateClientAuthenticity() throws {
         let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
         switch responseMode {
         case ResponseMode.directPost.rawValue, ResponseMode.directPostJwt.rawValue:
@@ -54,11 +53,10 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
            
         default:
             throw InvalidResponseMode(
-                message : "Given response_mode \(String(describing: responseMode)) is not supported",
+                message : "Given response_mode - \(responseMode ?? "nil") is not supported",
                 className: className
             )
         }
-
     }
 
     private func validateResponseUriMatchesClientId(authorizationRequestParameters: [String: Any]) throws {
@@ -70,7 +68,8 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
         if responseUriValue as? String != clientIdValue {
             throw InvalidData(
                 message: "\(AuthorizationRequestFieldConstants.responseUri) should be equal to client_id for given client_id_prefix",
-                className: className
+                className: className,
+                notifyVerifier: false
             )
         }
     }

--- a/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
+++ b/Sources/OpenID4VP/Exceptions/OpenId4VPExceptions.swift
@@ -136,8 +136,8 @@ class InvalidLimitDisclosure: OpenID4VPException {
 
 
 class InvalidData: OpenID4VPException {
-    init(message: String, className: String, code: String? = nil) {
-        super.init(errorCode: code ?? OpenID4VPErrorCodes.invalidRequest, message: message, className: className)
+    init(message: String, className: String, code: String? = nil, notifyVerifier: Bool = true) {
+        super.init(errorCode: code ?? OpenID4VPErrorCodes.invalidRequest, message: message, className: className, notifyVerifier: notifyVerifier)
     }
 }
 

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandlerFactory.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandlerFactory.swift
@@ -17,7 +17,7 @@ struct ResponseModeBasedHandlerFactory {
 
         default:
             throw InvalidData(
-                message: "Given response_mode - \(responseMode ?? "") is not supported",
+                message: "Given response_mode - \(responseMode ?? "nil") is not supported",
                 className: className,
                 code: OpenID4VPErrorCodes.invalidRequest
             )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
@@ -1094,7 +1094,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: ""], expectedError: "Given response_mode -  is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "nil"], expectedError: "Given response_mode - nil is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "null"], expectedError: "Given response_mode - null is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
-            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: nil], expectedError: "Given response_mode -  is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest)
+            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: nil], expectedError: "Given response_mode - nil is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest)
         ]
         
         for testCase in testCases {

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
@@ -119,21 +119,6 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         await XCTAssertAsyncNoThrowsError(try await preRegistered.validateAndParseRequestFields(), "Error should not happen when client_metadata is not known to wallet but provided in authorization request")
     }
     
-    func testThrowExceptionWhenClientIdIsAvailableInTrustedVerifiersButResponseUriIsNotMatching() async{
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
-            "client_id": "mock-client",
-            "response_uri": "https://some-other-url.com"
-        ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        
-        await XCTAssertAsyncThrowsError(try await preRegistered.validateAndParseRequestFields()){ error in
-            assertOpenID4VPException(error,
-                                     expectedMessage: "response_uri trust cannot be established",
-                                     expectedCode: OpenID4VPErrorCodes.invalidClient
-            )
-        }
-    }
-    
     /// Fetch authorization request by value - validate authorization request object and authorization request query paramaters - spec version draft 23
     
     func testFetchAuthorizationRequestOnValidPreRegisteredSchemeAuthRequestSentByValue() async{
@@ -422,6 +407,108 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         }
     }
     
+    func testValidateClientAuthenticity_validateTrustedVerifierFalse_doesNotThrow() {
+        let authorizationRequestParameters: [String: Any] = [
+            AuthorizationRequestFieldConstants.clientId: "mock-client",
+            AuthorizationRequestFieldConstants.responseUri: "https://some-unregistered-uri.com"
+        ]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            clientId: clientId,
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: createWalletConfig(validatePreregisteredVerifier: false),
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        XCTAssertNoThrow(try preRegistered.validateClientAuthenticity())
+    }
+
+    func testValidateClientAuthenticity_responseUriMatchesTrustedVerifier_doesNotThrow() {
+        let authorizationRequestParameters: [String: Any] = [
+            AuthorizationRequestFieldConstants.clientId: "mock-client",
+            AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com"
+        ]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            clientId: clientId,
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        XCTAssertNoThrow(try preRegistered.validateClientAuthenticity())
+    }
+
+    func testValidateClientAuthenticity_responseUriNotInTrustedVerifier_throwsInvalidVerifier() {
+        let authorizationRequestParameters: [String: Any] = [
+            AuthorizationRequestFieldConstants.clientId: "mock-client",
+            AuthorizationRequestFieldConstants.responseUri: "https://untrusted-uri.com"
+        ]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            clientId: clientId,
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        XCTAssertThrowsError(try preRegistered.validateClientAuthenticity()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "response_uri trust cannot be established",
+                expectedCode: OpenID4VPErrorCodes.invalidClient
+            )
+        }
+    }
+
+    func testValidateClientAuthenticity_clientIdNotInTrustedVerifiers_throwsInvalidVerifier() {
+        let authorizationRequestParameters: [String: Any] = [
+            AuthorizationRequestFieldConstants.clientId: "untrusted-client",
+            AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com"
+        ]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            clientId: clientId,
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        XCTAssertThrowsError(try preRegistered.validateClientAuthenticity()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Verifier is not trusted by the wallet",
+                expectedCode: OpenID4VPErrorCodes.invalidClient
+            )
+        }
+    }
+
+    func testValidateClientAuthenticity_responseUriMissingInRequest_throwsInvalidVerifier() {
+        let authorizationRequestParameters: [String: Any] = [
+            AuthorizationRequestFieldConstants.clientId: "mock-client"
+        ]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            clientId: clientId,
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        XCTAssertThrowsError(try preRegistered.validateClientAuthenticity()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "response_uri trust cannot be established",
+                expectedCode: OpenID4VPErrorCodes.invalidClient
+            )
+        }
+    }
+
     private func convertToJSONWebKey(_ jsonString: String) throws -> JWK {
         let data = jsonString.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(JWK.self, from: data)

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
@@ -487,15 +487,38 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         }
     }
 
-    func testValidateClientAuthenticity_responseUriMissingInRequest_throwsInvalidVerifier() {
+    func testValidateClientAuthenticity_responseUriMissingInRequest_throwsMissingInput() {
         let authorizationRequestParameters: [String: Any] = [
-            AuthorizationRequestFieldConstants.clientId: "mock-client"
+            AuthorizationRequestFieldConstants.clientId: clientId
         ]
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
             clientId: clientId,
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
+            setResponseUri: mockSetResponseUri,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        XCTAssertThrowsError(try preRegistered.validateClientAuthenticity()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Missing Input: response_uri param is required",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+    
+    func testValidateClientAuthenticity_responseUriNotAvailableInTrsutedList_throwsInvalidVerifier() {
+        let authorizationRequestParameters: [String: Any] = [
+            AuthorizationRequestFieldConstants.clientId: clientId,
+            AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com"
+        ]
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
+            clientId: clientId,
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: createWalletConfig(trustedVerifiers: [Verifier(clientId: clientId, responseUris: ["https://some-other-verifier.com"])]),
             setResponseUri: mockSetResponseUri,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
@@ -27,7 +27,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "untrusted-mock-client",
         ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-mock-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.validateClientId()) { error in
             assertOpenID4VPException(
@@ -41,7 +41,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testThrowExceptionWhenTrustedVerifiersListIsEmpty(){
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "other-mock-client","response_uri": "https://mock-verifier.com"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "other-mock-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.validateClientId()) { error in
             assertOpenID4VPException(
@@ -84,7 +84,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdNotAvailable_throwsError() {
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "untrusted-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.isUnsignedRequestSupported()) { error in
             assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
@@ -207,7 +207,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testExtractPublicKeyThrowErrorWhenPreRegisteredClientNotAvailable() async throws {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue, requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted-client"])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")){ error in
             assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
@@ -355,7 +355,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             paramList: authRequestWithPreRegisteredByValue,
             requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted-client"])
         ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1,
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
@@ -373,7 +373,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             paramList: authRequestWithPreRegisteredByValue,
             requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted-client"])
         ) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1,
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
@@ -470,7 +470,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com"
         ]
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(
-            clientId: clientId,
+            clientId: "untrusted-client",
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
@@ -46,18 +46,6 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         await XCTAssertAsyncNoThrowsError(try await redirectUriSchemeAuthRequestHandler.validateAndParseRequestFields())
     }
     
-    func testThrowErrorWhenClientIdIsNotEqualToResponseUriWithDirectPostResponseMode() async{
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter, ["response_uri": "http://invalid-mock-verifier.com"]), addEncryptionClientMetadataParams: false) as [String : Any]
-        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
-        
-        await XCTAssertAsyncThrowsError(try await redirectUriSchemeAuthRequestHandler.validateAndParseRequestFields()) { error in
-            assertOpenID4VPException(error,
-                                     expectedMessage: "response_uri should be equal to client_id for given client_id_prefix",
-                                     expectedCode: OpenID4VPErrorCodes.invalidRequest
-            )
-        }
-    }
-    
     func testThrowErrorWhenBothResponseUriAndRedirectUriPresentForDirectPost() {
         var authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter), addEncryptionClientMetadataParams: false) as [String : Any]
         authorizationRequestParameters[AuthorizationRequestFieldConstants.redirectUri] = "https://mock-verifier.com"
@@ -107,46 +95,6 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         
         assertDictionariesEqual(expected: expectedWalletMetadata, actual: (processedMetadata))
     }
-
-    func testShouldThrowErrorWhenResponseUriNotEqualToClientId() async {
-        let mockClientId = "http://mock-client.com"
-        let invalidResponseUri = "http://invalid-mock-client.com"
-        
-        let authParams: [String: Any] = createAuthorizationRequest(
-            paramList: authRequestWithRedirectUriByValue,
-            requestParams: mergeMaps(
-                authorizationRequestParamsWithValue,
-                redirectUriSchemeClientIdParameter,
-                [
-                    "client_id": mockClientId,
-                    "response_mode": "direct_post",
-                    "response_uri": invalidResponseUri,
-                    "scope": "openid",
-                    "response_type": "vp_token",
-                    "nonce": "123456"
-                ]
-            ),
-            addEncryptionClientMetadataParams: false
-        ) as [String : Any]
-        
-        let redirectUriSchemeHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
-            authorizationRequestParameters: authParams,
-            walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
-            walletNonce: "mock-nonce",
-            networkManager: mockNetworkManager
-        )
-        
-        await XCTAssertAsyncThrowsError(
-            try await redirectUriSchemeHandler.validateAndParseRequestFields()
-        ) { error in
-            assertOpenID4VPException(
-                error,
-                expectedMessage: "response_uri should be equal to client_id for given client_id_prefix",
-                expectedCode: OpenID4VPErrorCodes.invalidRequest
-            )
-        }
-    }
     
     func testThrowErrorWhenExtractPublicKeyIsInvoked() async {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter)) as [String : Any]
@@ -175,7 +123,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
             addEncryptionClientMetadataParams: false
         ) as [String : Any]
 
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
             setResponseUri: mockSetResponseUri,
@@ -237,7 +185,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
             )
         ) as [String : Any]
 
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
             setResponseUri: mockSetResponseUri,
@@ -259,7 +207,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
             addEncryptionClientMetadataParams: false
         ) as [String : Any]
 
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
             setResponseUri: mockSetResponseUri,
@@ -281,7 +229,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
             )
         ) as [String : Any]
 
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
             setResponseUri: mockSetResponseUri,
@@ -342,7 +290,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
             addEncryptionClientMetadataParams: false
         ) as [String : Any]
 
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
             setResponseUri: mockSetResponseUri,
@@ -367,7 +315,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
             )
         ) as [String : Any]
 
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, 
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
             setResponseUri: mockSetResponseUri,
@@ -379,6 +327,77 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     }
 
     
+    func testValidateClientAuthenticity_responseUriValidationModes_responseUriMissing_throwsMissingField() {
+        let responseUriValidationModes = ["direct_post", "direct_post.jwt"]
+        for responseMode in responseUriValidationModes {
+            let authorizationRequestParameters: [String: Any] = [
+                AuthorizationRequestFieldConstants.clientId: "redirect_uri:https://mock-verifier.com",
+                AuthorizationRequestFieldConstants.responseMode: responseMode
+            ]
+            let handler = RedirectUriPrefixAuthorizationRequestHandler(
+                clientId: clientId,
+                specVersion: .v1,
+                authorizationRequestParameters: authorizationRequestParameters,
+                walletConfig: walletConfig,
+                setResponseUri: mockSetResponseUri,
+                walletNonce: "mock-nonce",
+                networkManager: mockNetworkManager
+            )
+            XCTAssertThrowsError(try handler.validateClientAuthenticity(), "responseMode: \(responseMode)")
+        }
+    }
+
+    func testValidateClientAuthenticity_bypassResponseModes_doesNotValidateResponseUri_doesNotThrow() {
+        let bypassModes = ["iar-post", "iar-post.jwt", "iae_post", "iae_post.jwt"]
+        for responseMode in bypassModes {
+            let authorizationRequestParameters: [String: Any] = [
+                AuthorizationRequestFieldConstants.clientId: "redirect_uri:https://mock-verifier.com",
+                AuthorizationRequestFieldConstants.responseUri: "https://different-uri.com",
+                AuthorizationRequestFieldConstants.responseMode: responseMode
+            ]
+            let handler = RedirectUriPrefixAuthorizationRequestHandler(
+                clientId: clientId,
+                specVersion: .v1,
+                authorizationRequestParameters: authorizationRequestParameters,
+                walletConfig: walletConfig,
+                setResponseUri: mockSetResponseUri,
+                walletNonce: "mock-nonce",
+                networkManager: mockNetworkManager
+            )
+            XCTAssertNoThrow(try handler.validateClientAuthenticity(), "responseMode: \(responseMode)")
+        }
+    }
+
+    func testValidateClientAuthenticity_unsupportedResponseMode_throwsInvalidResponseMode() {
+        let unsupportedModes: [String?] = ["fragment", nil]
+        for responseMode in unsupportedModes {
+            var authorizationRequestParameters: [String: Any] = [
+                AuthorizationRequestFieldConstants.clientId: "redirect_uri:https://mock-verifier.com",
+                AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com"
+            ]
+            if let responseMode {
+                authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode] = responseMode
+            }
+            let handler = RedirectUriPrefixAuthorizationRequestHandler(
+                clientId: clientId,
+                specVersion: .v1,
+                authorizationRequestParameters: authorizationRequestParameters,
+                walletConfig: walletConfig,
+                setResponseUri: mockSetResponseUri,
+                walletNonce: "mock-nonce",
+                networkManager: mockNetworkManager
+            )
+            let expectedMessage = "Given response_mode - \(responseMode ?? "nil") is not supported"
+            XCTAssertThrowsError(try handler.validateClientAuthenticity(), "responseMode: \(String(describing: responseMode))") { error in
+                assertOpenID4VPException(
+                    error,
+                    expectedMessage: expectedMessage,
+                    expectedCode: OpenID4VPErrorCodes.invalidRequest
+                )
+            }
+        }
+    }
+
     func testValidateAndParseRequestFieldsSucceedsWithIaeMismatchedResponseUri() async {
 
         let testCases: [(responseMode: String, addEncryptionMetadata: Bool)] = [

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
@@ -343,7 +343,13 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
-            XCTAssertThrowsError(try handler.validateClientAuthenticity(), "responseMode: \(responseMode)")
+            XCTAssertThrowsError(try handler.validateClientAuthenticity(), "responseMode: \(responseMode)") { error in
+                assertOpenID4VPException(
+                    error,
+                    expectedMessage: "Missing Input: response_uri param is required",
+                    expectedCode: OpenID4VPErrorCodes.invalidRequest
+                )
+            }
         }
     }
 

--- a/Tests/OpenID4VPTests/ResponseModeHandler/ResponseModeBasedHandlerFactoryTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/ResponseModeBasedHandlerFactoryTests.swift
@@ -46,7 +46,7 @@ final class ResponseModeBasedHandlerFactoryTests: XCTestCase {
         ) { error in
             assertOpenID4VPException(
                 error,
-                expectedMessage: "Given response_mode -  is not supported",
+                expectedMessage: "Given response_mode - nil is not supported",
                 expectedCode: OpenID4VPErrorCodes.invalidRequest
             )
         }


### PR DESCRIPTION
Fixes: https://github.com/inji/inji-wallet/issues/2527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added client-authenticity validation into authorization request processing.
  - Enhanced trusted-verifier checks for client IDs and response URIs.
  - Added validation/bypass behavior for response URI handling based on supported response modes.
- **Bug Fixes**
  - Improved “unsupported response_mode” errors to show `nil` when the value is missing.
  - Suppressed verifier notifications for specific invalid response URI mismatches.
- **Tests**
  - Expanded and adjusted coverage for client authenticity, trusted verifiers, response URI requirements, and response mode validation/bypass cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->