### PR TITLE
fix(openid4vp-ios-swift) Ignore Invalid JWK in clientmetadata refers …

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadata.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadata.swift
@@ -39,7 +39,13 @@ public struct ClientMetadata: Codable {
             self.clientName = try container.decodeIfPresent(String.self, forKey: .clientName)
             self.logoUri = try container.decodeIfPresent(String.self, forKey: .logoUri)
             self.encryptedResponseEncValuesSupported = try container.decodeIfPresent([String].self, forKey: .encryptedResponseEncValuesSupported)
-            self.jwks = try container.decodeIfPresent(LenientJWKSet.self, forKey: .jwks)?.jwkSet
+            self.jwks = try container.decodeRequired(
+                LenientJWKSet.self,
+                forKey: .jwks,
+                fieldPath: ["client_metadata", "jwks"],
+                className: ClientMetadata.className,
+                isMandatory: false
+            )?.jwkSet
 
             let vpFormatsContainer = try container.nestedContainer(keyedBy: VPFormatType.self, forKey: .vpFormatsSupported)
             var decodedFormats: [String: VPFormatSupported] = [:]

--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadata.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadata.swift
@@ -39,7 +39,7 @@ public struct ClientMetadata: Codable {
             self.clientName = try container.decodeIfPresent(String.self, forKey: .clientName)
             self.logoUri = try container.decodeIfPresent(String.self, forKey: .logoUri)
             self.encryptedResponseEncValuesSupported = try container.decodeIfPresent([String].self, forKey: .encryptedResponseEncValuesSupported)
-            self.jwks = try container.decodeIfPresent(JWKSet.self, forKey: .jwks)
+            self.jwks = try container.decodeIfPresent(LenientJWKSet.self, forKey: .jwks)?.jwkSet
 
             let vpFormatsContainer = try container.nestedContainer(keyedBy: VPFormatType.self, forKey: .vpFormatsSupported)
             var decodedFormats: [String: VPFormatSupported] = [:]

--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadataDraft23.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadataDraft23.swift
@@ -64,12 +64,12 @@ public struct ClientMetadataDraft23: Codable {
             )!
             
             self .jwks = try container.decodeRequired(
-                JWKSet.self,
+                LenientJWKSet.self,
                 forKey: .jwks,
                 fieldPath: [AuthorizationRequestFieldConstants.clientMetadata, "jwks"],
                 className: ClientMetadataDraft23.className,
                 isMandatory: false
-            )
+            )?.jwkSet
             try validate(self)
         } catch {
             throw wrapError(error, customError: { message in InvalidData(message: "Error during client metadata decoding - \(message)", className: ClientMetadataDraft23.className) })

--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/LenientJWKSet.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/LenientJWKSet.swift
@@ -1,0 +1,29 @@
+import Foundation
+import JSONWebKey
+
+struct FailableDecodable<T: Decodable>: Decodable {
+    let value: T?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.value = try? container.decode(T.self)
+    }
+}
+
+struct LenientJWKSet: Decodable {
+    let keys: [JWK]
+
+    private enum CodingKeys: String, CodingKey {
+        case keys
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedKeys = try container.decodeIfPresent([FailableDecodable<JWK>].self, forKey: .keys) ?? []
+        self.keys = decodedKeys.compactMap { $0.value }
+    }
+
+    var jwkSet: JWKSet {
+        JWKSet(keys: keys)
+    }
+}

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataSpecVersionDraft23Tests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataSpecVersionDraft23Tests.swift
@@ -2,6 +2,34 @@ import XCTest
 @testable import OpenID4VP
 
 final class ClientMetadataSpecVersionDraft23Tests: XCTestCase {
+
+    private let mixedJwks = """
+    {
+        "keys": [
+            {
+                "kty": "EC",
+                "use": "enc",
+                "alg": "ECDH-ES",
+                "kid": "valid-enc-key",
+                "crv": "P-256",
+                "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+            },
+            {
+                "kty": "AKP",
+                "alg": "ML-KEM-9999",
+                "use": "enc",
+                "kid": "post-quantum-key"
+            },
+            {
+                "kty": "OIDF-CONFORMANCE-UNSUPPORTED",
+                "use": "enc",
+                "kid": "unsupported-key"
+            }
+        ]
+    }
+    """
+
     func testThrowErrorOnValidationOfInvalidClientMetadataNew() {
             let testCases: [TestCase] = [
                 TestCase(
@@ -139,5 +167,23 @@ final class ClientMetadataSpecVersionDraft23Tests: XCTestCase {
         for testCase in testCases {
             XCTAssertNoThrow(try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: testCase.input))
         }
+    }
+
+    func testDraft23IgnoresUnusableEncryptionKeys() throws {
+        let input = """
+        {
+            "client_name": "Test Client",
+            "logo_uri": "https://example.com/logo.png",
+            "authorization_encrypted_response_alg": "ECDH-ES",
+            "authorization_encrypted_response_enc": "A256GCM",
+            "vp_formats": { "ldp_vp": { "proof_type_values": ["Ed25519Signature2020"] } },
+            "jwks": \(mixedJwks)
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: input)
+
+        XCTAssertEqual(metadata.jwks?.keys.count, 1)
+        XCTAssertEqual(metadata.jwks?.keys.first?.keyID, "valid-enc-key")
     }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataTests.swift
@@ -7,6 +7,33 @@ final class ClientMetadataTests: XCTestCase {
     {"keys": [{"kty": "EC", "use": "enc", "alg": "ECDH-ES", "kid": "1", "crv": "P-256", "x": "ur76rg", "y": "ur76rg"}]}
     """
 
+    private let mixedJwks = """
+    {
+        "keys": [
+            {
+                "kty": "EC",
+                "use": "enc",
+                "alg": "ECDH-ES",
+                "kid": "valid-enc-key",
+                "crv": "P-256",
+                "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+            },
+            {
+                "kty": "AKP",
+                "alg": "ML-KEM-9999",
+                "use": "enc",
+                "kid": "post-quantum-key"
+            },
+            {
+                "kty": "OIDF-CONFORMANCE-UNSUPPORTED",
+                "use": "enc",
+                "kid": "unsupported-key"
+            }
+        ]
+    }
+    """
+
     // MARK: - init (memberwise)
 
     func testInitStoresAllFields() {
@@ -232,8 +259,25 @@ final class ClientMetadataTests: XCTestCase {
         }
     }
 
+    // MARK: - jwks decoding
+
+    func testV1IgnoresUnusableEncryptionKeys() throws {
+        let data = json(jwks: mixedJwks)
+
+        let decoded = try JSONDecoder().decode(ClientMetadata.self, from: data)
+
+        XCTAssertEqual(decoded.jwks?.keys.count, 1)
+        XCTAssertEqual(decoded.jwks?.keys.first?.keyID, "valid-enc-key")
+    }
+
+    func testV1RejectsExplicitNullJwks() {
+        let data = json(jwks: "null")
+
+        XCTAssertThrowsError(try JSONDecoder().decode(ClientMetadata.self, from: data))
+    }
+
     // MARK: - Helper methods
-    
+
     private func json(
         clientName: String? = "\"Test Client\"",
         logoUri: String? = "\"https://example.com/logo.png\"",

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
@@ -5,6 +5,23 @@ import XCTest
 // Test: oid4vp-1final-wallet-ignores-unusable-encryption-key
 final class LenientJWKSetTests: XCTestCase {
 
+    // A single usable EC encryption key.
+    private let validJwks = """
+    {
+        "keys": [
+            {
+                "kty": "EC",
+                "use": "enc",
+                "alg": "ECDH-ES",
+                "kid": "valid-enc-key",
+                "crv": "P-256",
+                "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+            }
+        ]
+    }
+    """
+
     // A JWKS with one usable EC encryption key, a post-quantum AKP/ML-KEM key
     // and a key with an unsupported key type.
     private let mixedJwks = """
@@ -34,6 +51,36 @@ final class LenientJWKSetTests: XCTestCase {
     }
     """
 
+    // MARK: - LenientJWKSet decoding
+
+    func testParsesValidJwks() throws {
+        let decoded = try JSONDecoder().decode(LenientJWKSet.self, from: validJwks.data(using: .utf8)!)
+
+        XCTAssertEqual(decoded.keys.count, 1)
+        XCTAssertEqual(decoded.jwkSet.keys.first?.keyID, "valid-enc-key")
+    }
+
+    func testIgnoresUnusableKeysAndKeepsValidOnes() throws {
+        let decoded = try JSONDecoder().decode(LenientJWKSet.self, from: mixedJwks.data(using: .utf8)!)
+
+        XCTAssertEqual(decoded.keys.count, 1)
+        XCTAssertEqual(decoded.jwkSet.keys.first?.keyID, "valid-enc-key")
+    }
+
+    func testDefaultsToEmptyKeysWhenKeysArrayMissing() throws {
+        let decoded = try JSONDecoder().decode(LenientJWKSet.self, from: "{}".data(using: .utf8)!)
+
+        XCTAssertTrue(decoded.keys.isEmpty)
+    }
+
+    // MARK: - ClientMetadata wiring
+    //
+    // These only verify that ClientMetadata / ClientMetadataDraft23 are wired to
+    // LenientJWKSet correctly (i.e. an invalid/unusable JWK does not break
+    // client metadata parsing, and an explicit null jwks is still rejected).
+    // The underlying decoding/leniency behaviour is already covered above, so
+    // each wiring scenario is exercised once rather than for both formats.
+
     func testDraft23IgnoresUnusableEncryptionKeys() throws {
         let input = """
         {
@@ -50,38 +97,6 @@ final class LenientJWKSetTests: XCTestCase {
 
         XCTAssertEqual(metadata.jwks?.keys.count, 1)
         XCTAssertEqual(metadata.jwks?.keys.first?.keyID, "valid-enc-key")
-    }
-
-    func testV1IgnoresUnusableEncryptionKeys() throws {
-        let input = """
-        {
-            "client_name": "Test Client",
-            "logo_uri": "https://example.com/logo.png",
-            "encrypted_response_enc_values_supported": ["A256GCM"],
-            "vp_formats_supported": { "ldp_vc": { "proof_type_values": ["Ed25519Signature2020"] } },
-            "jwks": \(mixedJwks)
-        }
-        """.data(using: .utf8)!
-
-        let metadata = try JSONDecoder().decode(ClientMetadata.self, from: input)
-
-        XCTAssertEqual(metadata.jwks?.keys.count, 1)
-        XCTAssertEqual(metadata.jwks?.keys.first?.keyID, "valid-enc-key")
-    }
-
-    func testDraft23StillRejectsExplicitNullJwks() {
-        let input = """
-        {
-            "client_name": "Test Client",
-            "logo_uri": "https://example.com/logo.png",
-            "authorization_encrypted_response_alg": "ECDH-ES",
-            "authorization_encrypted_response_enc": "A256GCM",
-            "vp_formats": { "ldp_vp": { "proof_type_values": ["Ed25519Signature2020"] } },
-            "jwks": null
-        }
-        """.data(using: .utf8)!
-
-        XCTAssertThrowsError(try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: input))
     }
 
     func testV1RejectsExplicitNullJwks() {

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
@@ -83,4 +83,33 @@ final class LenientJWKSetTests: XCTestCase {
 
         XCTAssertThrowsError(try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: input))
     }
+
+    func testV1RejectsExplicitNullJwks() {
+        let input = """
+        {
+            "client_name": "Test Client",
+            "logo_uri": "https://example.com/logo.png",
+            "encrypted_response_enc_values_supported": ["A256GCM"],
+            "vp_formats_supported": { "ldp_vc": { "proof_type_values": ["Ed25519Signature2020"] } },
+            "jwks": null
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try JSONDecoder().decode(ClientMetadata.self, from: input))
+    }
+
+    func testV1AcceptsOmittedJwks() throws {
+        let input = """
+        {
+            "client_name": "Test Client",
+            "logo_uri": "https://example.com/logo.png",
+            "encrypted_response_enc_values_supported": ["A256GCM"],
+            "vp_formats_supported": { "ldp_vc": { "proof_type_values": ["Ed25519Signature2020"] } }
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(ClientMetadata.self, from: input)
+
+        XCTAssertNil(metadata.jwks)
+    }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
@@ -1,11 +1,8 @@
 import XCTest
 @testable import OpenID4VP
 
-// https://github.com/inji/inji-wallet/issues/2531
-// Test: oid4vp-1final-wallet-ignores-unusable-encryption-key
 final class LenientJWKSetTests: XCTestCase {
 
-    // A single usable EC encryption key.
     private let validJwks = """
     {
         "keys": [
@@ -22,8 +19,6 @@ final class LenientJWKSetTests: XCTestCase {
     }
     """
 
-    // A JWKS with one usable EC encryption key, a post-quantum AKP/ML-KEM key
-    // and a key with an unsupported key type.
     private let mixedJwks = """
     {
         "keys": [
@@ -51,8 +46,6 @@ final class LenientJWKSetTests: XCTestCase {
     }
     """
 
-    // MARK: - LenientJWKSet decoding
-
     func testParsesValidJwks() throws {
         let decoded = try JSONDecoder().decode(LenientJWKSet.self, from: validJwks.data(using: .utf8)!)
 
@@ -71,60 +64,5 @@ final class LenientJWKSetTests: XCTestCase {
         let decoded = try JSONDecoder().decode(LenientJWKSet.self, from: "{}".data(using: .utf8)!)
 
         XCTAssertTrue(decoded.keys.isEmpty)
-    }
-
-    // MARK: - ClientMetadata wiring
-    //
-    // These only verify that ClientMetadata / ClientMetadataDraft23 are wired to
-    // LenientJWKSet correctly (i.e. an invalid/unusable JWK does not break
-    // client metadata parsing, and an explicit null jwks is still rejected).
-    // The underlying decoding/leniency behaviour is already covered above, so
-    // each wiring scenario is exercised once rather than for both formats.
-
-    func testDraft23IgnoresUnusableEncryptionKeys() throws {
-        let input = """
-        {
-            "client_name": "Test Client",
-            "logo_uri": "https://example.com/logo.png",
-            "authorization_encrypted_response_alg": "ECDH-ES",
-            "authorization_encrypted_response_enc": "A256GCM",
-            "vp_formats": { "ldp_vp": { "proof_type_values": ["Ed25519Signature2020"] } },
-            "jwks": \(mixedJwks)
-        }
-        """.data(using: .utf8)!
-
-        let metadata = try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: input)
-
-        XCTAssertEqual(metadata.jwks?.keys.count, 1)
-        XCTAssertEqual(metadata.jwks?.keys.first?.keyID, "valid-enc-key")
-    }
-
-    func testV1RejectsExplicitNullJwks() {
-        let input = """
-        {
-            "client_name": "Test Client",
-            "logo_uri": "https://example.com/logo.png",
-            "encrypted_response_enc_values_supported": ["A256GCM"],
-            "vp_formats_supported": { "ldp_vc": { "proof_type_values": ["Ed25519Signature2020"] } },
-            "jwks": null
-        }
-        """.data(using: .utf8)!
-
-        XCTAssertThrowsError(try JSONDecoder().decode(ClientMetadata.self, from: input))
-    }
-
-    func testV1AcceptsOmittedJwks() throws {
-        let input = """
-        {
-            "client_name": "Test Client",
-            "logo_uri": "https://example.com/logo.png",
-            "encrypted_response_enc_values_supported": ["A256GCM"],
-            "vp_formats_supported": { "ldp_vc": { "proof_type_values": ["Ed25519Signature2020"] } }
-        }
-        """.data(using: .utf8)!
-
-        let metadata = try JSONDecoder().decode(ClientMetadata.self, from: input)
-
-        XCTAssertNil(metadata.jwks)
     }
 }

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/LenientJWKSetTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import OpenID4VP
+
+// https://github.com/inji/inji-wallet/issues/2531
+// Test: oid4vp-1final-wallet-ignores-unusable-encryption-key
+final class LenientJWKSetTests: XCTestCase {
+
+    // A JWKS with one usable EC encryption key, a post-quantum AKP/ML-KEM key
+    // and a key with an unsupported key type.
+    private let mixedJwks = """
+    {
+        "keys": [
+            {
+                "kty": "EC",
+                "use": "enc",
+                "alg": "ECDH-ES",
+                "kid": "valid-enc-key",
+                "crv": "P-256",
+                "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+            },
+            {
+                "kty": "AKP",
+                "alg": "ML-KEM-9999",
+                "use": "enc",
+                "kid": "post-quantum-key"
+            },
+            {
+                "kty": "OIDF-CONFORMANCE-UNSUPPORTED",
+                "use": "enc",
+                "kid": "unsupported-key"
+            }
+        ]
+    }
+    """
+
+    func testDraft23IgnoresUnusableEncryptionKeys() throws {
+        let input = """
+        {
+            "client_name": "Test Client",
+            "logo_uri": "https://example.com/logo.png",
+            "authorization_encrypted_response_alg": "ECDH-ES",
+            "authorization_encrypted_response_enc": "A256GCM",
+            "vp_formats": { "ldp_vp": { "proof_type_values": ["Ed25519Signature2020"] } },
+            "jwks": \(mixedJwks)
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: input)
+
+        XCTAssertEqual(metadata.jwks?.keys.count, 1)
+        XCTAssertEqual(metadata.jwks?.keys.first?.keyID, "valid-enc-key")
+    }
+
+    func testV1IgnoresUnusableEncryptionKeys() throws {
+        let input = """
+        {
+            "client_name": "Test Client",
+            "logo_uri": "https://example.com/logo.png",
+            "encrypted_response_enc_values_supported": ["A256GCM"],
+            "vp_formats_supported": { "ldp_vc": { "proof_type_values": ["Ed25519Signature2020"] } },
+            "jwks": \(mixedJwks)
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(ClientMetadata.self, from: input)
+
+        XCTAssertEqual(metadata.jwks?.keys.count, 1)
+        XCTAssertEqual(metadata.jwks?.keys.first?.keyID, "valid-enc-key")
+    }
+
+    func testDraft23StillRejectsExplicitNullJwks() {
+        let input = """
+        {
+            "client_name": "Test Client",
+            "logo_uri": "https://example.com/logo.png",
+            "authorization_encrypted_response_alg": "ECDH-ES",
+            "authorization_encrypted_response_enc": "A256GCM",
+            "vp_formats": { "ldp_vp": { "proof_type_values": ["Ed25519Signature2020"] } },
+            "jwks": null
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try ClientMetadataDraft23.deserializeAndValidate(clientMetadata: input))
+    }
+}


### PR DESCRIPTION
@coderabbitai refer this issue  the pr has the changes as per this github issue https://github.com/orgs/inji/projects/4/views/19?pane=issue&itemId=4874323299&issue=inji%7Cinji-wallet%7C2531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added more tolerant JWKS parsing that retains usable keys while skipping invalid or unsupported entries.

* **Bug Fixes**
  * Improved client metadata handling for mixed or malformed JWKS payloads.
  * Missing key lists now default to an empty JWKS set, while explicit `jwks: null` remains rejected.

* **Tests**
  * Added coverage for valid, mixed, unsupported, missing-key, and null-JWKS scenarios across supported metadata formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->