### PR TITLE
fix: Error response in direct_post.jwt response mode not encrypted

### DIFF
--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequest.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequest.swift
@@ -58,7 +58,7 @@ public class AuthorizationRequest: Encodable {
     
     static func validateAndCreateAuthorizationRequest(urlEncodedAuthorizationRequest: String,
                                                       walletConfig: WalletConfig,
-                                                      setResponseUri: @escaping (String) -> Void,
+                                                      setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
                                                       walletNonce: String,
                                                       networkManager: NetworkManaging
     ) async throws -> AuthorizationRequest {
@@ -66,7 +66,7 @@ public class AuthorizationRequest: Encodable {
         
         return try await getAuthorizationRequest(authorizationRequestParameters: extractedQueryParameters,
                                                  walletConfig: walletConfig,
-                                                 setResponseUri: setResponseUri,
+                                                 setResponseDispatchInfo: setResponseDispatchInfo,
                                                  walletNonce: walletNonce,
                                                  networkManager: networkManager)
     }
@@ -75,14 +75,14 @@ public class AuthorizationRequest: Encodable {
     static func validateAndCreateAuthorizationRequest(
         authRequest: [String: Any],
         walletConfig: WalletConfig,
-        setResponseUri: @escaping (String) -> Void,
+        setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
         walletNonce: String,
         networkManager: NetworkManaging
     ) async throws -> AuthorizationRequest {
         return try await getAuthorizationRequest(
             authorizationRequestParameters: authRequest,
             walletConfig: walletConfig,
-            setResponseUri: setResponseUri,
+            setResponseDispatchInfo: setResponseDispatchInfo,
             walletNonce: walletNonce,
             networkManager: networkManager
         )
@@ -90,13 +90,13 @@ public class AuthorizationRequest: Encodable {
     
     private static func getAuthorizationRequest(authorizationRequestParameters: [String: Any],
                                                 walletConfig: WalletConfig,
-                                                setResponseUri: @escaping (String) -> Void,
+                                                setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
                                                 walletNonce: String,
                                                 networkManager: NetworkManaging
     ) async throws -> AuthorizationRequest {
         let authorizationRequestHandler = try getAuthorizationRequestHandler(authorizationRequestParameters: authorizationRequestParameters,
                                                                                walletConfig: walletConfig,
-                                                                               setResponseUri: setResponseUri,
+                                                                               setResponseDispatchInfo: setResponseDispatchInfo,
                                                                                walletNonce: walletNonce,
                                                                                networkManager: networkManager)
         

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -289,6 +289,9 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         
         let responseEncryptionSpecification = try specVersionHandler.validateClientMetadataAsPerResponseModeAndGetResponseEncryptionSpecification(authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata)
         self.responseDispatchInfo?.responseEncryptionSpecification = responseEncryptionSpecification
+        if let dispatchInfo = self.responseDispatchInfo {
+            setResponseDispatchInfo(dispatchInfo)
+        }
         
         try await specVersionHandler.validatePresentationRequest(authorizationRequestParameters: &authorizationRequestParameters,walletConfig: walletConfig, networkManager: networkManager)
     }

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -83,8 +83,10 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
             }
         }
         
+        guard let nonce = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.nonce]) else {
+            throw InvalidInput(fieldPath: [AuthorizationRequestFieldConstants.nonce], className: className, notifyVerifier: false)
+        }
         let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
-        let nonce = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.nonce])!
         let state = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.state])
         let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: responseMode)
         let responseUrl = try responseModeHandler.getResponseEndpoint(authorizationRequestParameters: authorizationRequestParameters)

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -24,6 +24,7 @@ extension AbstractMethodsForClientIdPrefixBasedAuthorizationRequestHandler {
 class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
     var delegate: AbstractMethodsForClientIdPrefixBasedAuthorizationRequestHandler!
     let clientId: String
+    var responseDispatchInfo: ResponseDispatchInfo?
     var authorizationRequestParameters: [String: Any]
     let walletConfig: WalletConfig
     let setResponseUri: (String) -> Void
@@ -61,8 +62,29 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         try await self.fetchAuthorizationRequest()
         try delegate.validateClientAuthenticity()
         try self.setResponseUrl()
+        try self.prepareDispatchInfo()
         try await self.validateAndParseRequestFields()
         return self.createAuthorizationRequest()
+    }
+    
+    func prepareDispatchInfo() throws {
+        // missing nonce is not notified to the verifier
+        try validateAttribute(AuthorizationRequestFieldConstants.nonce, values: authorizationRequestParameters, notifyVerifier: false)
+        
+        let optionalFields = [AuthorizationRequestFieldConstants.state, AuthorizationRequestFieldConstants.responseMode]
+        for field in optionalFields {
+            if (authorizationRequestParameters[field] != nil){
+                try validateAttribute(field, values: authorizationRequestParameters)
+            }
+        }
+        
+        let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode]) ?? ResponseMode.directPost.rawValue
+        let nonce = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.nonce])!
+        let state = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.state])
+        let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: responseMode)
+        let responseUrl = try responseModeHandler.getResponseEndpoint(authorizationRequestParameters: authorizationRequestParameters)
+        
+        self.responseDispatchInfo = ResponseDispatchInfo(responseMode: responseMode, nonce: nonce, walletNonce: self.walletNonce, state: state, clientId: self.clientId, responseUrl: responseUrl, responseEncryptionSpecification: nil)
     }
     
     func validateClientId() throws {
@@ -244,19 +266,12 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         }
         try validateAttribute(AuthorizationRequestFieldConstants.responseType, values: authorizationRequestParameters)
 
-        // missing nonce is not notified to the verifier
-        try validateAttribute(AuthorizationRequestFieldConstants.nonce, values: authorizationRequestParameters, notifyVerifier: false)
-
         try validateResponseTypeSupported((authorizationRequestParameters[AuthorizationRequestFieldConstants.responseType] as? String)!)
         
-        let optionalFields = [AuthorizationRequestFieldConstants.state, AuthorizationRequestFieldConstants.responseMode]
-        for field in optionalFields {
-            if (authorizationRequestParameters[field] != nil){
-                try validateAttribute(field, values: authorizationRequestParameters)
-            }
-        }
-        
         authorizationRequestParameters = try specVersionHandler.parseAndValidateClientMetadata(authorizationRequest: authorizationRequestParameters, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata, walletConfig: walletConfig)
+        
+        let responseEncryptionSpecification = try specVersionHandler.validateClientMetadataAsPerResponseModeAndGetResponseEncryptionSpecification(authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata)
+        self.responseDispatchInfo?.responseEncryptionSpecification = responseEncryptionSpecification
         
         try await specVersionHandler.validatePresentationRequest(authorizationRequestParameters: &authorizationRequestParameters,walletConfig: walletConfig, networkManager: networkManager)
     }
@@ -339,6 +354,26 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         func parseAndValidateClientMetadata(authorizationRequest: [String: Any], shouldValidateWithWalletMetadata: Bool, walletConfig: WalletConfig) throws -> [String: Any] {
             let clientMetadataHandler: ClientMetadataSpecVersionHandler = self == .draft23 ? .draft23 : .v1
             return try clientMetadataHandler.parseAndValidate(authorizationRequest: authorizationRequest, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata, walletConfig: walletConfig)
+        }
+        
+        func validateClientMetadataAsPerResponseModeAndGetResponseEncryptionSpecification(authorizationRequestParameters: [String: Any], walletConfig: WalletConfig, shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
+            let parsedClientMetadata = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientMetadata]
+            let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode]))
+                                                                                
+            return switch self {
+            case .specV1:
+                try responseModeHandler.validate(
+                    clientMetadata: (parsedClientMetadata as? ClientMetadata),
+                    walletConfig: walletConfig,
+                    shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata
+                )
+            case .draft23:
+                try responseModeHandler.validate(
+                    clientMetadata: (parsedClientMetadata as? ClientMetadataDraft23),
+                    walletConfig: walletConfig,
+                    shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata
+                )
+            }
         }
 
         func validatePresentationRequest(authorizationRequestParameters: inout [String: Any], walletConfig: WalletConfig, networkManager: NetworkManaging) async throws {

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -86,7 +86,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         guard let nonce = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.nonce]) else {
             throw InvalidInput(fieldPath: [AuthorizationRequestFieldConstants.nonce], className: className, notifyVerifier: false)
         }
-        let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
+        let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode]) ?? ResponseMode.directPost.rawValue
         let state = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.state])
         let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: responseMode)
         let responseUrl = try responseModeHandler.getResponseEndpoint(authorizationRequestParameters: authorizationRequestParameters)
@@ -103,7 +103,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
             }
         }
         
-        self.responseDispatchInfo = ResponseDispatchInfo(responseMode: responseMode!, nonce: nonce, walletNonce: self.walletNonce, state: state, clientId: self.clientId, responseUrl: responseUrl, responseEncryptionSpecification: nil)
+        self.responseDispatchInfo = ResponseDispatchInfo(responseMode: responseMode, nonce: nonce, walletNonce: self.walletNonce, state: state, clientId: self.clientId, responseUrl: responseUrl, responseEncryptionSpecification: nil)
     }
     
     func validateClientId() throws {
@@ -285,7 +285,10 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         }
         try validateAttribute(AuthorizationRequestFieldConstants.responseType, values: authorizationRequestParameters)
         
-        try validateResponseTypeSupported((authorizationRequestParameters[AuthorizationRequestFieldConstants.responseType] as? String)!)
+        guard let responseType = authorizationRequestParameters[AuthorizationRequestFieldConstants.responseType] as? String else {
+            throw InvalidInput(fieldPath: [AuthorizationRequestFieldConstants.responseType], className: className)
+        }
+        try validateResponseTypeSupported(responseType)
         
         authorizationRequestParameters = try specVersionHandler.parseAndValidateClientMetadata(authorizationRequest: authorizationRequestParameters, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata, walletConfig: walletConfig)
         

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -27,7 +27,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
     var responseDispatchInfo: ResponseDispatchInfo?
     var authorizationRequestParameters: [String: Any]
     let walletConfig: WalletConfig
-    let setResponseUri: (String) -> Void
+    let setResponseDispatchInfo: (ResponseDispatchInfo) -> Void
     let walletNonce: String
     let networkManager: NetworkManaging
     private var specVersionHandler: SpecVersionHandler = .specV1
@@ -41,11 +41,11 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
          specVersion: SpecVersion,
          authorizationRequestParameters: [String: Any],
          walletConfig: WalletConfig,
-         setResponseUri: @escaping (String) -> Void,
+         setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
          walletNonce: String,
          networkManager: NetworkManaging = NetworkManager()) {
         self.authorizationRequestParameters = authorizationRequestParameters
-        self.setResponseUri = setResponseUri
+        self.setResponseDispatchInfo = setResponseDispatchInfo
         self.networkManager = networkManager
         self.walletConfig = walletConfig
         self.walletNonce = walletNonce
@@ -61,9 +61,16 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         try self.validateClientId()
         try await self.fetchAuthorizationRequest()
         try delegate.validateClientAuthenticity()
-        try self.setResponseUrl()
         try self.prepareDispatchInfo()
+        // Notify early so error URLs are available if validateAndParseRequestFields throws
+        if let dispatchInfo = self.responseDispatchInfo {
+            setResponseDispatchInfo(dispatchInfo)
+        }
         try await self.validateAndParseRequestFields()
+        // Notify again with complete dispatch info (including encryption spec)
+        if let dispatchInfo = self.responseDispatchInfo {
+            setResponseDispatchInfo(dispatchInfo)
+        }
         return self.createAuthorizationRequest()
     }
     
@@ -78,13 +85,25 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
             }
         }
         
-        let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode]) ?? ResponseMode.directPost.rawValue
+        let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
         let nonce = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.nonce])!
         let state = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.state])
         let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: responseMode)
         let responseUrl = try responseModeHandler.getResponseEndpoint(authorizationRequestParameters: authorizationRequestParameters)
         
-        self.responseDispatchInfo = ResponseDispatchInfo(responseMode: responseMode, nonce: nonce, walletNonce: self.walletNonce, state: state, clientId: self.clientId, responseUrl: responseUrl, responseEncryptionSpecification: nil)
+        
+        
+        // redirect_uri must not be present for direct_post / direct_post.jwt
+        if responseMode == ResponseMode.directPost.rawValue || responseMode == ResponseMode.directPostJwt.rawValue {
+            if authorizationRequestParameters.keys.contains(AuthorizationRequestFieldConstants.redirectUri) {
+                throw InvalidData(
+                    message: "\(AuthorizationRequestFieldConstants.redirectUri) should not be present for given response_mode",
+                    className: className
+                )
+            }
+        }
+        
+        self.responseDispatchInfo = ResponseDispatchInfo(responseMode: responseMode!, nonce: nonce, walletNonce: self.walletNonce, state: state, clientId: self.clientId, responseUrl: responseUrl, responseEncryptionSpecification: nil)
     }
     
     func validateClientId() throws {
@@ -121,7 +140,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         // After fetching the VP request, populate version logic
         specVersionHandler = SpecVersionHandler.from(specVersion)
     }
-
+    
     private func handleRequestObjectAsValue(_ request: String) async throws {
         try validate(request, fieldPath: AuthorizationRequestFieldConstants.request, className: className)
         guard (delegate.isSignedRequestSupported()) else {
@@ -265,7 +284,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
             throw InvalidTransactionData(message: "Invalid Request: transaction_data is not supported in the authorization request", className: className)
         }
         try validateAttribute(AuthorizationRequestFieldConstants.responseType, values: authorizationRequestParameters)
-
+        
         try validateResponseTypeSupported((authorizationRequestParameters[AuthorizationRequestFieldConstants.responseType] as? String)!)
         
         authorizationRequestParameters = try specVersionHandler.parseAndValidateClientMetadata(authorizationRequest: authorizationRequestParameters, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata, walletConfig: walletConfig)
@@ -274,25 +293,6 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         self.responseDispatchInfo?.responseEncryptionSpecification = responseEncryptionSpecification
         
         try await specVersionHandler.validatePresentationRequest(authorizationRequestParameters: &authorizationRequestParameters,walletConfig: walletConfig, networkManager: networkManager)
-    }
-    
-    final func setResponseUrl() throws {
-        let responseMode = getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode])
-
-        // redirect_uri must not be present for direct_post / direct_post.jwt
-        if responseMode == ResponseMode.directPost.rawValue || responseMode == ResponseMode.directPostJwt.rawValue {
-            if authorizationRequestParameters.keys.contains(AuthorizationRequestFieldConstants.redirectUri) {
-                throw InvalidData(
-                    message: "\(AuthorizationRequestFieldConstants.redirectUri) should not be present for given response_mode",
-                    className: className
-                )
-            }
-        }
-
-        let responseUri = try ResponseModeBasedHandlerFactory
-            .get(responseMode: responseMode)
-            .setResponseUrl(authorizationRequestParameters: authorizationRequestParameters)
-        setResponseUri(responseUri)
     }
     
     private func isClientIdPrefixSupported(walletConfig: WalletConfig) throws {
@@ -350,7 +350,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         static func from(_ specVersion: SpecVersion) -> SpecVersionHandler {
             return specVersion == .v1 ? .specV1 : .draft23
         }
-
+        
         func parseAndValidateClientMetadata(authorizationRequest: [String: Any], shouldValidateWithWalletMetadata: Bool, walletConfig: WalletConfig) throws -> [String: Any] {
             let clientMetadataHandler: ClientMetadataSpecVersionHandler = self == .draft23 ? .draft23 : .v1
             return try clientMetadataHandler.parseAndValidate(authorizationRequest: authorizationRequest, shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata, walletConfig: walletConfig)
@@ -359,7 +359,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         func validateClientMetadataAsPerResponseModeAndGetResponseEncryptionSpecification(authorizationRequestParameters: [String: Any], walletConfig: WalletConfig, shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
             let parsedClientMetadata = authorizationRequestParameters[AuthorizationRequestFieldConstants.clientMetadata]
             let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: getStringValue(authorizationRequestParameters[AuthorizationRequestFieldConstants.responseMode]))
-                                                                                
+            
             return switch self {
             case .specV1:
                 try responseModeHandler.validate(
@@ -375,7 +375,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
                 )
             }
         }
-
+        
         func validatePresentationRequest(authorizationRequestParameters: inout [String: Any], walletConfig: WalletConfig, networkManager: NetworkManaging) async throws {
             switch self {
             case .specV1:
@@ -387,7 +387,7 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
                     }
                 }
                 return
-           case .draft23:
+            case .draft23:
                 authorizationRequestParameters = try await parseAndValidatePresentationDefinition(authorizationRequestParameters, walletConfig.isPresentationDefinitionUriSupported, networkManager)
             }
         }

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -274,7 +274,10 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
             }
         }
 
-        try ResponseModeBasedHandlerFactory.get(responseMode: responseMode).setResponseUrl(authorizationRequestParameters: authorizationRequestParameters,setResponseUri: setResponseUri)
+        let responseUri = try ResponseModeBasedHandlerFactory
+            .get(responseMode: responseMode)
+            .setResponseUrl(authorizationRequestParameters: authorizationRequestParameters)
+        setResponseUri(responseUri)
     }
     
     private func isClientIdPrefixSupported(walletConfig: WalletConfig) throws {

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestHandler.swift
@@ -62,12 +62,10 @@ class ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass  {
         try await self.fetchAuthorizationRequest()
         try delegate.validateClientAuthenticity()
         try self.prepareDispatchInfo()
-        // Notify early so error URLs are available if validateAndParseRequestFields throws
         if let dispatchInfo = self.responseDispatchInfo {
             setResponseDispatchInfo(dispatchInfo)
         }
         try await self.validateAndParseRequestFields()
-        // Notify again with complete dispatch info (including encryption spec)
         if let dispatchInfo = self.responseDispatchInfo {
             setResponseDispatchInfo(dispatchInfo)
         }

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandler.swift
@@ -4,14 +4,14 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandler:  ClientIdPrefixB
                   specVersion: SpecVersion,
                   authorizationRequestParameters: [String: Any],
                   walletConfig: WalletConfig,
-                  setResponseUri: @escaping (String) -> Void,
+                  setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
                   walletNonce: String,
                   networkManager: NetworkManaging) {
         super.init(clientId: clientId,
                    specVersion: specVersion,
                    authorizationRequestParameters: authorizationRequestParameters,
                    walletConfig: walletConfig,
-                   setResponseUri: setResponseUri,
+                   setResponseDispatchInfo: setResponseDispatchInfo,
                    walletNonce: walletNonce,
                    networkManager: networkManager)
         delegate = self

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredPrefixAuthorizationRequestHandler.swift
@@ -7,14 +7,14 @@ class PreRegisteredSchemeAuthorizationRequestHandler:  ClientIdPrefixBasedAuthor
          specVersion: SpecVersion,
          authorizationRequestParameters: [String: Any],
          walletConfig: WalletConfig,
-         setResponseUri: @escaping (String) -> Void,
+         setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
          walletNonce: String,
          networkManager: NetworkManaging) {
         super.init(clientId: clientId,
                    specVersion: specVersion,
                    authorizationRequestParameters: authorizationRequestParameters,
                    walletConfig: walletConfig,
-                   setResponseUri: setResponseUri,
+                   setResponseDispatchInfo: setResponseDispatchInfo,
                    walletNonce: walletNonce,
                    networkManager: networkManager)
         delegate = self

--- a/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriPrefixAuthorizationRequestHandler.swift
@@ -4,14 +4,14 @@ class RedirectUriPrefixAuthorizationRequestHandler:  ClientIdPrefixBasedAuthoriz
                   specVersion: SpecVersion,
                   authorizationRequestParameters: [String: Any],
                   walletConfig: WalletConfig,
-                  setResponseUri: @escaping (String) -> Void,
+                  setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
                   walletNonce: String,
                   networkManager: NetworkManaging) {
         super.init(clientId: clientId,
                    specVersion: specVersion,
                    authorizationRequestParameters: authorizationRequestParameters,
                    walletConfig: walletConfig,
-                   setResponseUri: setResponseUri,
+                   setResponseDispatchInfo: setResponseDispatchInfo,
                    walletNonce: walletNonce,
                    networkManager: networkManager)
         delegate = self

--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadataUtil.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadataUtil.swift
@@ -45,8 +45,6 @@ enum ClientMetadataSpecVersionHandler {
             }
         }
         
-        let responseMode = authorizationRequest[AuthorizationRequestFieldConstants.responseMode] as? String
-        
         return mutableParams
     }
         

--- a/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadataUtil.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/ClientMetadata/ClientMetadataUtil.swift
@@ -46,21 +46,6 @@ enum ClientMetadataSpecVersionHandler {
         }
         
         let responseMode = authorizationRequest[AuthorizationRequestFieldConstants.responseMode] as? String
-        let parsedClientMetadata = mutableParams[clientMetadataKey]
-        switch self {
-        case .v1:
-            try ResponseModeBasedHandlerFactory.get(responseMode: responseMode).validate(
-                clientMetadata: (parsedClientMetadata as? ClientMetadata),
-                walletConfig: walletConfig,
-                shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata
-            )
-        case .draft23:
-            try ResponseModeBasedHandlerFactory.get(responseMode: responseMode).validate(
-                clientMetadata: (parsedClientMetadata as? ClientMetadataDraft23),
-                walletConfig: walletConfig,
-                shouldValidateWithWalletMetadata: shouldValidateWithWalletMetadata
-            )
-        }
         
         return mutableParams
     }

--- a/Sources/OpenID4VP/AuthorizationRequest/Utils/AuthorizationRequestUtils.swift
+++ b/Sources/OpenID4VP/AuthorizationRequest/Utils/AuthorizationRequestUtils.swift
@@ -72,7 +72,7 @@ extension KeyedDecodingContainer {
 
 func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any],
                                     walletConfig: WalletConfig,
-                                    setResponseUri: @escaping (String) -> Void,
+                                    setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
                                     walletNonce: String,
                                     networkManager: NetworkManaging
 ) throws -> ClientIdPrefixBasedAuthorizationRequestHandler {
@@ -88,7 +88,7 @@ func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any]
                                                               specVersion: specVersion,
                                                               authorizationRequestParameters: authorizationRequestParameters,
                                                               walletConfig: walletConfig,
-                                                              setResponseUri: setResponseUri,
+                                                              setResponseDispatchInfo: setResponseDispatchInfo,
                                                               walletNonce: walletNonce,
                                                               networkManager: networkManager)
     case ClientIdScheme.did.rawValue, ClientIdPrefix.decentralizedIdentifier.rawValue:
@@ -96,7 +96,7 @@ func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any]
                                                     specVersion: specVersion,
                                                     authorizationRequestParameters: authorizationRequestParameters,
                                                                         walletConfig: walletConfig,
-                                                    setResponseUri: setResponseUri,
+                                                    setResponseDispatchInfo: setResponseDispatchInfo,
                                                     walletNonce: walletNonce,
                                                     networkManager: networkManager)
     case ClientIdPrefix.redirectUri.rawValue:
@@ -104,7 +104,7 @@ func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any]
                                                             specVersion: specVersion,
                                                             authorizationRequestParameters: authorizationRequestParameters,
                                                             walletConfig: walletConfig,
-                                                            setResponseUri: setResponseUri,
+                                                            setResponseDispatchInfo: setResponseDispatchInfo,
                                                             walletNonce: walletNonce,
                                                             networkManager: networkManager)
     default:
@@ -113,7 +113,7 @@ func getAuthorizationRequestHandler(authorizationRequestParameters: [String:Any]
                                                               specVersion: specVersion,
                                                               authorizationRequestParameters: authorizationRequestParameters,
                                                               walletConfig: walletConfig,
-                                                              setResponseUri: setResponseUri,
+                                                              setResponseDispatchInfo: setResponseDispatchInfo,
                                                               walletNonce: walletNonce,
                                                               networkManager: networkManager)
     }

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -101,7 +101,7 @@ class AuthorizationResponseHandler {
     ) async throws -> VerifierResponse {
         let authorizationResponse : AuthorizationResponse
         do {
-            guard let dispatchInfo = dispatchInfo else {
+            if dispatchInfo == nil {
                 throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send authorization response to verifier.", className: Self.className)
             }
             let reconstructedVpTokenSigningResult : [FormatType : [VPTokenSigningResult]] = try constructSigningResults(

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -99,6 +99,39 @@ public class AuthorizationResponseHandler {
         }
     }
     
+    func sendAuthorizationError(dispatchInfo: ResponseDispatchInfo?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> VerifierResponse {
+        guard let dispatchInfo = dispatchInfo else {
+            throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
+        }
+        
+        let resolvedError: OpenID4VPException
+        if let openidError = error as? OpenID4VPException {
+            resolvedError = openidError
+        } else {
+            resolvedError = GenericFailure(
+                message: error.localizedDescription.isEmpty ? "Unknown internal error" : error.localizedDescription,
+                className: String(describing: OpenID4VP.self)
+            )
+        }
+        
+        let state = dispatchInfo.state
+        let authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(state: state)
+        
+        let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
+        
+        do {
+            let networkResponse = try await responseModeHandler.sendAuthorizationError(dispatchInfo: dispatchInfo, authorizationResponse: authorizationErrorResponse, networkManager: networkManager)
+            let verifierResponse = toVerifierResponse(networkResponse)
+            (error as? OpenID4VPException)?.setVerifierResponse(verifierResponse)
+            return verifierResponse
+        } catch {
+            throw ErrorDispatchFailure(
+                message: "Failed to send error to verifier: \(error)",
+                className: Self.className
+            )
+        }
+    }
+    
     func constructAndSendAuthorizationResponseToVerifier(
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: [VPTokenSigningResult],

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -46,7 +46,7 @@ class AuthorizationResponseHandler {
             )
             
             guard let dispatchInfo = dispatchInfo else {
-                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
+                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot construct VP response.", className: Self.className)
             }
             
             
@@ -100,10 +100,10 @@ class AuthorizationResponseHandler {
         dispatchInfo: ResponseDispatchInfo?
     ) async throws -> VerifierResponse {
         let authorizationResponse : AuthorizationResponse
+        guard let dispatchInfo = dispatchInfo else {
+            throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send authorization response to verifier.", className: Self.className)
+        }
         do {
-            if dispatchInfo == nil {
-                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
-            }
             let reconstructedVpTokenSigningResult : [FormatType : [VPTokenSigningResult]] = try constructSigningResults(
                 unsignedVPTokenResults: unsignedVPTokenResults,
                 signingResults: vpTokenSigningResults
@@ -118,7 +118,7 @@ class AuthorizationResponseHandler {
         }
         
         let response: NetworkResponse = try await sendAuthorizationResponse(
-            dispatchInfo: dispatchInfo!,
+            dispatchInfo: dispatchInfo,
             authorizationResponse: authorizationResponse,
             authorizationRequest: authorizationRequest
         )

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -100,10 +100,10 @@ class AuthorizationResponseHandler {
         dispatchInfo: ResponseDispatchInfo?
     ) async throws -> VerifierResponse {
         let authorizationResponse : AuthorizationResponse
-        guard let dispatchInfo = dispatchInfo else {
-            throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send authorization response to verifier.", className: Self.className)
-        }
         do {
+            guard let dispatchInfo = dispatchInfo else {
+                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send authorization response to verifier.", className: Self.className)
+            }
             let reconstructedVpTokenSigningResult : [FormatType : [VPTokenSigningResult]] = try constructSigningResults(
                 unsignedVPTokenResults: unsignedVPTokenResults,
                 signingResults: vpTokenSigningResults
@@ -118,7 +118,7 @@ class AuthorizationResponseHandler {
         }
         
         let response: NetworkResponse = try await sendAuthorizationResponse(
-            dispatchInfo: dispatchInfo,
+            dispatchInfo: dispatchInfo!,
             authorizationResponse: authorizationResponse,
             authorizationRequest: authorizationRequest
         )

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -63,48 +63,6 @@ class AuthorizationResponseHandler {
         }
     }
     
-    func sendAuthorizationError(responseUri: String?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> VerifierResponse {
-        guard let responseUri = responseUri, !responseUri.isEmpty else {
-            throw ErrorDispatchFailure(message: "Response URI is not set. Cannot send error to verifier.", className: Self.className)
-        }
-        
-        var errorPayload: [String: String] = [:]
-        
-        let resolvedError: OpenID4VPException
-        if let openidError = error as? OpenID4VPException {
-            resolvedError = openidError
-        } else {
-            resolvedError = GenericFailure(
-                message: error.localizedDescription.isEmpty ? "Unknown internal error" : error.localizedDescription,
-                className: String(describing: OpenID4VP.self)
-            )
-        }
-        
-        errorPayload.merge(resolvedError.toErrorResponse()) { _, new in new }
-        
-        if let state = authorizationRequest?.state, !state.isEmpty {
-            errorPayload["state"] = state
-        }
-        
-        do {
-            let dispatchResult = try await networkManager.sendHTTPRequest(
-                url: responseUri,
-                method: .post,
-                bodyParams: errorPayload,
-                headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
-            )
-            let verifierResponse: VerifierResponse = toVerifierResponse(dispatchResult)
-            
-            (error as? OpenID4VPException)?.setVerifierResponse(verifierResponse)
-            return verifierResponse
-        } catch {
-            throw ErrorDispatchFailure(
-                message: "Failed to send error to verifier: \(error)",
-                className: Self.className
-            )
-        }
-    }
-    
     func sendAuthorizationError(dispatchInfo: ResponseDispatchInfo?, authorizationRequest: AuthorizationRequest?, error: Error) async throws -> VerifierResponse {
         guard let dispatchInfo = dispatchInfo else {
             throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
@@ -143,7 +101,7 @@ class AuthorizationResponseHandler {
     ) async throws -> VerifierResponse {
         let authorizationResponse : AuthorizationResponse
         do {
-            guard let dispatchInfo = dispatchInfo else {
+            if dispatchInfo == nil {
                 throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
             }
             let reconstructedVpTokenSigningResult : [FormatType : [VPTokenSigningResult]] = try constructSigningResults(
@@ -259,42 +217,6 @@ class AuthorizationResponseHandler {
         }
         
         return unsignedVPTokenResults.values.flatMap { $0.1 }
-    }
-    
-    func constructAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        exception: Error,
-        walletNonce: String
-    ) -> [String: Any] {
-        self.walletNonce = walletNonce
-        
-        let authorizationResponse: AuthorizationErrorResponse
-        
-        if let openIDException = exception as? OpenID4VPException {
-            authorizationResponse = openIDException.toAuthorizationErrorResponse(state: authorizationRequest?.state)
-        } else {
-            let genericException = GenericFailure(
-                message: exception.localizedDescription.isEmpty ? "Unknown internal error" : exception.localizedDescription,
-                className: String(describing: OpenID4VP.self)
-            )
-            authorizationResponse = genericException.toAuthorizationErrorResponse(state: authorizationRequest?.state)
-        }
-        
-        do {
-            return try ResponseModeBasedHandlerFactory
-                .get(responseMode: authorizationRequest?.responseMode ?? ResponseMode.directPost.rawValue)
-                .getAuthorizationErrorResponse(
-                    authorizationRequest: authorizationRequest,
-                    authorizationResponse: authorizationResponse,
-                    walletNonce: self.walletNonce
-                )
-        } catch {
-            OpenID4VPException.error(error, className: Self.className)
-            return [
-                "error": "invalid_request",
-                "error_description": "Failed to construct error response: \(error.localizedDescription)"
-            ]
-        }
     }
     
     func constructAuthorizationErrorResponse(

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-public class AuthorizationResponseHandler {
+class AuthorizationResponseHandler {
     private let networkManager: NetworkManaging
     private var walletNonce: String = ""
     private var formatToCredentialInputDescriptorMapping: [FormatType: [CredentialInputDescriptorMapping]] = [:]
@@ -11,9 +11,9 @@ public class AuthorizationResponseHandler {
     private var specVersion: SpecVersion = .v1
     private let walletConfig: WalletConfig
     
-    public static let className = String(describing: AuthorizationResponseHandler.self)
+    static let className = String(describing: AuthorizationResponseHandler.self)
     
-    public init(networkManager: NetworkManaging, walletConfig: WalletConfig) {
+    init(networkManager: NetworkManaging, walletConfig: WalletConfig) {
         self.networkManager = networkManager
         self.walletConfig = walletConfig
     }
@@ -33,7 +33,8 @@ public class AuthorizationResponseHandler {
     
     func constructVPResponse(
         signingResults: [VPTokenSigningResult],
-        authorizationRequest: AuthorizationRequest
+        authorizationRequest: AuthorizationRequest,
+        dispatchInfo: ResponseDispatchInfo?
     ) throws -> [String: String] {
         do {
             let authorizationResponse = try createAuthorizationResponse(
@@ -43,7 +44,19 @@ public class AuthorizationResponseHandler {
                     signingResults: signingResults
                 )
             )
-            
+
+            var resolvedDispatchInfo = dispatchInfo
+            resolvedDispatchInfo?.nonce = authorizationRequest.nonce
+
+            if let info = resolvedDispatchInfo {
+                return try ResponseModeBasedHandlerFactory
+                    .get(responseMode: info.responseMode)
+                    .getAuthorizationResponse(
+                        dispatchInfo: info,
+                        authorizationResponse: authorizationResponse
+                    )
+            }
+
             return try ResponseModeBasedHandlerFactory
                 .get(responseMode: authorizationRequest.responseMode)
                 .getAuthorizationResponse(
@@ -103,7 +116,7 @@ public class AuthorizationResponseHandler {
         guard let dispatchInfo = dispatchInfo else {
             throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
         }
-        
+    
         let resolvedError: OpenID4VPException
         if let openidError = error as? OpenID4VPException {
             resolvedError = openidError
@@ -114,9 +127,7 @@ public class AuthorizationResponseHandler {
             )
         }
         
-        let state = dispatchInfo.state
-        let authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(state: state)
-        
+        let authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(state: dispatchInfo.state)
         let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
         
         do {
@@ -135,10 +146,13 @@ public class AuthorizationResponseHandler {
     func constructAndSendAuthorizationResponseToVerifier(
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: [VPTokenSigningResult],
-        responseUri: String
+        dispatchInfo: ResponseDispatchInfo?
     ) async throws -> VerifierResponse {
         let authorizationResponse : AuthorizationResponse
         do {
+            guard dispatchInfo != nil else {
+                throw UnsupportedOperationException(message: "Response URI is not available to send any response to Verifier", className: Self.className)
+            }
             let reconstructedVpTokenSigningResult : [FormatType : [VPTokenSigningResult]] = try constructSigningResults(
                 unsignedVPTokenResults: unsignedVPTokenResults,
                 signingResults: vpTokenSigningResults
@@ -153,9 +167,8 @@ public class AuthorizationResponseHandler {
         }
         
         let response: NetworkResponse = try await sendAuthorizationResponse(
-            authorizationRequest: authorizationRequest,
-            authorizationResponse: authorizationResponse,
-            responseUri: responseUri
+            dispatchInfo: dispatchInfo!,
+            authorizationResponse: authorizationResponse
         )
         return toVerifierResponse(response)
     }
@@ -290,10 +303,44 @@ public class AuthorizationResponseHandler {
         }
     }
     
+    func constructAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo?,
+        error: Error,
+        walletNonce: String
+    ) -> [String: Any] {
+        
+        
+        let resolvedError: OpenID4VPException
+        if let openidError = error as? OpenID4VPException {
+            resolvedError = openidError
+        } else {
+            resolvedError = GenericFailure(
+                message: error.localizedDescription.isEmpty ? "Unknown internal error" : error.localizedDescription,
+                className: String(describing: OpenID4VP.self)
+            )
+        }
+        do {
+            guard let dispatchInfo = dispatchInfo else {
+                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
+            }
+            let authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(state: dispatchInfo.state)
+            let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
+            
+            return try responseModeHandler.getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationErrorResponse)
+        }  catch {
+            OpenID4VPException.error(error, className: Self.className)
+            return [
+                "error": "invalid_request",
+                "error_description": "Failed to construct error response: \(error.localizedDescription)"
+            ]
+        }
+    }
+    
     private func createAuthorizationResponse(
         authorizationRequest: AuthorizationRequest,
         vpTokenSigningResults: [FormatType: [VPTokenSigningResult]]
     ) throws -> AuthorizationResponse {
+        
         
         switch authorizationRequest.responseType {
         case ResponseType.vp_token.rawValue:
@@ -397,19 +444,14 @@ public class AuthorizationResponseHandler {
     }
     
     private func sendAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        responseUri: String
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse
     ) async throws -> NetworkResponse {
-        return try await ResponseModeBasedHandlerFactory.get(responseMode: authorizationRequest.responseMode)
+        return try await ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
             .sendAuthorizationResponse(
-                authorizationRequest: authorizationRequest,
+                dispatchInfo: dispatchInfo,
                 authorizationResponse: authorizationResponse,
-                url: responseUri,
-                networkManager: networkManager,
-                producerInfo: walletNonce,
-                recipientInfo: authorizationRequest.nonce,
-                walletConfig: walletConfig
+                networkManager: networkManager
             )
     }
     

--- a/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/AuthorizationResponseHandler.swift
@@ -44,27 +44,20 @@ class AuthorizationResponseHandler {
                     signingResults: signingResults
                 )
             )
-
-            var resolvedDispatchInfo = dispatchInfo
-            resolvedDispatchInfo?.nonce = authorizationRequest.nonce
-
-            if let info = resolvedDispatchInfo {
-                return try ResponseModeBasedHandlerFactory
-                    .get(responseMode: info.responseMode)
-                    .getAuthorizationResponse(
-                        dispatchInfo: info,
-                        authorizationResponse: authorizationResponse
-                    )
+            
+            guard let dispatchInfo = dispatchInfo else {
+                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
             }
-
+            
+            
             return try ResponseModeBasedHandlerFactory
-                .get(responseMode: authorizationRequest.responseMode)
+                .get(responseMode: dispatchInfo.responseMode)
                 .getAuthorizationResponse(
-                    authorizationRequest: authorizationRequest,
+                    dispatchInfo: dispatchInfo,
                     authorizationResponse: authorizationResponse,
-                    walletNonce: walletNonce,
-                    walletConfig: walletConfig
+                    authorizationRequest: authorizationRequest
                 )
+            
         } catch {
             throw AuthorizationResponseConstructionFailure(cause: error, className: Self.className)
         }
@@ -131,7 +124,7 @@ class AuthorizationResponseHandler {
         let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
         
         do {
-            let networkResponse = try await responseModeHandler.sendAuthorizationError(dispatchInfo: dispatchInfo, authorizationResponse: authorizationErrorResponse, networkManager: networkManager)
+            let networkResponse = try await responseModeHandler.sendAuthorizationError(dispatchInfo: dispatchInfo, authorizationResponse: authorizationErrorResponse, authorizationRequest: authorizationRequest, networkManager: networkManager)
             let verifierResponse = toVerifierResponse(networkResponse)
             (error as? OpenID4VPException)?.setVerifierResponse(verifierResponse)
             return verifierResponse
@@ -150,8 +143,8 @@ class AuthorizationResponseHandler {
     ) async throws -> VerifierResponse {
         let authorizationResponse : AuthorizationResponse
         do {
-            guard dispatchInfo != nil else {
-                throw UnsupportedOperationException(message: "Response URI is not available to send any response to Verifier", className: Self.className)
+            guard let dispatchInfo = dispatchInfo else {
+                throw ErrorDispatchFailure(message: "Response dispatch details are not set. Cannot send error to verifier.", className: Self.className)
             }
             let reconstructedVpTokenSigningResult : [FormatType : [VPTokenSigningResult]] = try constructSigningResults(
                 unsignedVPTokenResults: unsignedVPTokenResults,
@@ -168,7 +161,8 @@ class AuthorizationResponseHandler {
         
         let response: NetworkResponse = try await sendAuthorizationResponse(
             dispatchInfo: dispatchInfo!,
-            authorizationResponse: authorizationResponse
+            authorizationResponse: authorizationResponse,
+            authorizationRequest: authorizationRequest
         )
         return toVerifierResponse(response)
     }
@@ -306,7 +300,8 @@ class AuthorizationResponseHandler {
     func constructAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo?,
         error: Error,
-        walletNonce: String
+        walletNonce: String,
+        authorizationRequest: AuthorizationRequest? = nil
     ) -> [String: Any] {
         
         
@@ -326,7 +321,7 @@ class AuthorizationResponseHandler {
             let authorizationErrorResponse = resolvedError.toAuthorizationErrorResponse(state: dispatchInfo.state)
             let responseModeHandler = try ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
             
-            return try responseModeHandler.getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationErrorResponse)
+            return try responseModeHandler.getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationErrorResponse, authorizationRequest: authorizationRequest)
         }  catch {
             OpenID4VPException.error(error, className: Self.className)
             return [
@@ -445,12 +440,14 @@ class AuthorizationResponseHandler {
     
     private func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationResponse
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
     ) async throws -> NetworkResponse {
         return try await ResponseModeBasedHandlerFactory.get(responseMode: dispatchInfo.responseMode)
             .sendAuthorizationResponse(
                 dispatchInfo: dispatchInfo,
                 authorizationResponse: authorizationResponse,
+                authorizationRequest: authorizationRequest,
                 networkManager: networkManager
             )
     }

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/Mdoc/UnsignedMdocVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/Mdoc/UnsignedMdocVPTokenBuilder.swift
@@ -21,7 +21,13 @@ struct UnsignedMdocVPTokenBuilder: UnsignedVPTokenBuilder {
         self.authorizationRequest = authorizationRequest
         self.specVersion = specVersion
         self.walletConfig = walletConfig
-        self.responseUri = try ResponseModeBasedHandlerFactory.get(responseMode: authorizationRequest.responseMode).getResponseEndpoint(authorizationRequest: authorizationRequest)
+        var responseEndpointParameters: [String: Any] = [:]
+        if let responseUri = authorizationRequest.responseUri {
+            responseEndpointParameters[AuthorizationRequestFieldConstants.responseUri] = responseUri
+        }
+        self.responseUri = try ResponseModeBasedHandlerFactory
+            .get(responseMode: authorizationRequest.responseMode)
+            .getResponseEndpoint(authorizationRequestParameters: responseEndpointParameters)
         self.mdocGeneratedNonce = mdocGeneratedNonce
     }
     
@@ -188,4 +194,3 @@ struct UnsignedMdocVPTokenBuilder: UnsignedVPTokenBuilder {
         }
     }
 }
-

--- a/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/Mdoc/UnsignedMdocVPTokenBuilder.swift
+++ b/Sources/OpenID4VP/AuthorizationResponse/UnsignedVPToken/types/Mdoc/UnsignedMdocVPTokenBuilder.swift
@@ -21,13 +21,9 @@ struct UnsignedMdocVPTokenBuilder: UnsignedVPTokenBuilder {
         self.authorizationRequest = authorizationRequest
         self.specVersion = specVersion
         self.walletConfig = walletConfig
-        var responseEndpointParameters: [String: Any] = [:]
-        if let responseUri = authorizationRequest.responseUri {
-            responseEndpointParameters[AuthorizationRequestFieldConstants.responseUri] = responseUri
-        }
         self.responseUri = try ResponseModeBasedHandlerFactory
             .get(responseMode: authorizationRequest.responseMode)
-            .getResponseEndpoint(authorizationRequestParameters: responseEndpointParameters)
+            .getResponseEndpoint(authorizationRequest: authorizationRequest)
         self.mdocGeneratedNonce = mdocGeneratedNonce
     }
     

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -153,7 +153,8 @@ public class OpenID4VP {
     }
 
     public func sendErrorInfoToVerifier(error: Error) async throws -> VerifierResponse {
-        return try await authorizationResponseHandler.sendAuthorizationError(responseUri: responseDispatchInfo?.responseUrl ?? responseUri, authorizationRequest: authorizationRequest, error: error)
+        return try await authorizationResponseHandler.sendAuthorizationError(dispatchInfo: responseDispatchInfo, authorizationRequest: authorizationRequest, error: error)
+        
     }
 
     private func safeSendError(error: Error) async {

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -147,7 +147,8 @@ public class OpenID4VP {
         return authorizationResponseHandler.constructAuthorizationErrorResponse(
             dispatchInfo: responseDispatchInfo,
             error: exception,
-            walletNonce: walletNonce
+            walletNonce: walletNonce,
+            authorizationRequest: authorizationRequest
         )
     }
 

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -45,7 +45,6 @@ public class OpenID4VP {
         walletNonce = nonceProvider.generateNonce()
         authorizationRequest = nil
         responseDispatchInfo = nil
-        responseDispatchInfo = nil
         authorizationResponseHandler = AuthorizationResponseHandler(networkManager: networkManager, walletConfig: walletConfig)
 
         do {

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -5,6 +5,7 @@ public class OpenID4VP {
     let networkManager: NetworkManaging
     var authorizationRequest: AuthorizationRequest!
     private var responseUri: String?
+    private var responseDispatchInfo: ResponseDispatchInfo?
     private var authorizationResponseHandler: AuthorizationResponseHandler
     private let walletConfig: WalletConfig
     private var walletNonce: String = ""
@@ -36,6 +37,10 @@ public class OpenID4VP {
 
     internal func setResponseUri(_ responseUri: String) {
         self.responseUri = responseUri
+    }
+    
+    internal func setResponseDispatchInfo(_ responseDispatchInfo: ResponseDispatchInfo) {
+        self.responseDispatchInfo = responseDispatchInfo
     }
     
     public func authenticateVerifier(

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -45,7 +45,7 @@ public class OpenID4VP {
         // Create a new wallet nonce for each request
         walletNonce = nonceProvider.generateNonce()
         authorizationRequest = nil
-        responseUri = nil
+        responseDispatchInfo = nil
         responseDispatchInfo = nil
         authorizationResponseHandler = AuthorizationResponseHandler(networkManager: networkManager, walletConfig: walletConfig)
 
@@ -119,37 +119,36 @@ public class OpenID4VP {
     public func constructVPResponse(vpTokenSigningResults: [VPTokenSigningResult]) -> [String: Any] {
         do {
             return try authorizationResponseHandler.constructVPResponse(
-                signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest
+                signingResults: vpTokenSigningResults,
+                authorizationRequest: authorizationRequest,
+                dispatchInfo: responseDispatchInfo
             )
         } catch let exception {
             return constructErrorInfo(exception: exception)
         }
     }
 
-    public func constructErrorInfo(exception: Error) -> [String: Any] {
-        return authorizationResponseHandler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: exception,
-            walletNonce: walletNonce
-        )
-    }
-
     public func sendVPResponseToVerifier(
         vpTokenSigningResults: [VPTokenSigningResult]
     ) async throws -> VerifierResponse {
         do {
-            guard let responseUrl = responseDispatchInfo?.responseUrl else {
-                throw UnsupportedOperationException(message: "Response URI is not available to send any response to Verifier", className: className)
-            }
             return try await authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest: authorizationRequest,
                 vpTokenSigningResults: vpTokenSigningResults,
-                responseUri: responseUrl
+                dispatchInfo: responseDispatchInfo
             )
         } catch {
              await safeSendError(error: error)
             throw error
         }
+    }
+    
+    public func constructErrorInfo(exception: Error) -> [String: Any] {
+        return authorizationResponseHandler.constructAuthorizationErrorResponse(
+            dispatchInfo: responseDispatchInfo,
+            error: exception,
+            walletNonce: walletNonce
+        )
     }
 
     public func sendErrorInfoToVerifier(error: Error) async throws -> VerifierResponse {

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -34,10 +34,6 @@ public class OpenID4VP {
         self.walletConfig = walletConfig
         OpenID4VPException.setTraceabilityId(className: String(describing: type(of: self)), traceabilityId: traceabilityId)
     }
-
-    internal func setResponseUri(_ responseUri: String) {
-        self.responseUri = responseUri
-    }
     
     internal func setResponseDispatchInfo(_ responseDispatchInfo: ResponseDispatchInfo) {
         self.responseDispatchInfo = responseDispatchInfo
@@ -50,13 +46,14 @@ public class OpenID4VP {
         walletNonce = nonceProvider.generateNonce()
         authorizationRequest = nil
         responseUri = nil
+        responseDispatchInfo = nil
         authorizationResponseHandler = AuthorizationResponseHandler(networkManager: networkManager, walletConfig: walletConfig)
 
         do {
             authorizationRequest = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: urlEncodedAuthorizationRequest,
                 walletConfig: walletConfig,
-                setResponseUri: setResponseUri,
+                setResponseDispatchInfo: setResponseDispatchInfo,
                 walletNonce: walletNonce,
                 networkManager: networkManager
             )
@@ -75,12 +72,13 @@ public class OpenID4VP {
             walletNonce = nonceProvider.generateNonce()
             self.authorizationRequest = nil
             responseUri = nil
+            responseDispatchInfo = nil
             authorizationResponseHandler = AuthorizationResponseHandler(networkManager: networkManager, walletConfig: walletConfig)
 
             let validatedAuthorizationRequest = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 authRequest: authorizationRequest,
                 walletConfig: walletConfig,
-                setResponseUri: setResponseUri,
+                setResponseDispatchInfo: setResponseDispatchInfo,
                 walletNonce: walletNonce,
                 networkManager: networkManager
             )
@@ -140,13 +138,13 @@ public class OpenID4VP {
         vpTokenSigningResults: [VPTokenSigningResult]
     ) async throws -> VerifierResponse {
         do {
-            guard let responseUri = responseUri else {
+            guard let responseUrl = responseDispatchInfo?.responseUrl else {
                 throw UnsupportedOperationException(message: "Response URI is not available to send any response to Verifier", className: className)
             }
             return try await authorizationResponseHandler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest: authorizationRequest,
                 vpTokenSigningResults: vpTokenSigningResults,
-                responseUri: responseUri
+                responseUri: responseUrl
             )
         } catch {
              await safeSendError(error: error)
@@ -155,7 +153,7 @@ public class OpenID4VP {
     }
 
     public func sendErrorInfoToVerifier(error: Error) async throws -> VerifierResponse {
-        return try await authorizationResponseHandler.sendAuthorizationError(responseUri: responseUri, authorizationRequest: authorizationRequest, error: error)
+        return try await authorizationResponseHandler.sendAuthorizationError(responseUri: responseDispatchInfo?.responseUrl ?? responseUri, authorizationRequest: authorizationRequest, error: error)
     }
 
     private func safeSendError(error: Error) async {

--- a/Sources/OpenID4VP/OpenID4VP.swift
+++ b/Sources/OpenID4VP/OpenID4VP.swift
@@ -4,7 +4,6 @@ public class OpenID4VP {
     public let traceabilityId: String
     let networkManager: NetworkManaging
     var authorizationRequest: AuthorizationRequest!
-    private var responseUri: String?
     private var responseDispatchInfo: ResponseDispatchInfo?
     private var authorizationResponseHandler: AuthorizationResponseHandler
     private let walletConfig: WalletConfig
@@ -71,7 +70,6 @@ public class OpenID4VP {
         do {
             walletNonce = nonceProvider.generateNonce()
             self.authorizationRequest = nil
-            responseUri = nil
             responseDispatchInfo = nil
             authorizationResponseHandler = AuthorizationResponseHandler(networkManager: networkManager, walletConfig: walletConfig)
 

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseDispatchInfo.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseDispatchInfo.swift
@@ -1,0 +1,28 @@
+import Foundation
+import JSONWebKey
+
+/**
+ * Data class that holds information required for dispatching responses to the verifier.
+ */
+struct ResponseDispatchInfo {
+    let responseMode: String
+    let nonce: String?
+    let walletNonce: String?
+    let state: String?
+    let clientId: String
+    let responseUrl: String
+    var responseEncryptionSpecification: ResponseEncryptionSpecification?
+}
+
+/**
+ * Specification for encrypting authorization responses.
+ *
+ * @property keyEncryptionAlg The algorithm used for key encryption (e.g., "ECDH-ES")
+ * @property contentEncryptionAlg The algorithm used for content encryption (e.g., "A256GCM")
+ * @property verifierPublicKey The verifier's public key (JWK) used for encryption
+ */
+struct ResponseEncryptionSpecification {
+    let keyEncryptionAlg: EncryptionAlgorithm
+    let contentEncryptionAlg: EncryptionMethod
+    let verifierPublicKey: JWK
+}

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseDispatchInfo.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseDispatchInfo.swift
@@ -5,13 +5,13 @@ import JSONWebKey
  * Data class that holds information required for dispatching responses to the verifier.
  */
 struct ResponseDispatchInfo {
-    public let responseMode: String
-    public var nonce: String?
-    public var walletNonce: String?
-    public let state: String?
-    public let clientId: String
-    public let responseUrl: String
-    public var responseEncryptionSpecification: ResponseEncryptionSpecification?
+    let responseMode: String
+    let nonce: String?
+    let walletNonce: String?
+    let state: String?
+    let clientId: String
+    let responseUrl: String
+    var responseEncryptionSpecification: ResponseEncryptionSpecification?
 }
 
 /**
@@ -19,10 +19,10 @@ struct ResponseDispatchInfo {
  *
  * @property keyEncryptionAlg The algorithm used for key encryption (e.g., "ECDH-ES")
  * @property contentEncryptionAlg The algorithm used for content encryption (e.g., "A256GCM")
- * @property verifierPublicKey The verifier's public key (JWK) used for encryption
+ * @property verifierPublicKey The verifier's key (JWK) used for encryption
  */
 struct ResponseEncryptionSpecification {
-    public let keyEncryptionAlg: EncryptionAlgorithm
-    public let contentEncryptionAlg: EncryptionMethod
-    public let verifierPublicKey: JWK
+    let keyEncryptionAlg: EncryptionAlgorithm
+    let contentEncryptionAlg: EncryptionMethod
+    let verifierPublicKey: JWK
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseDispatchInfo.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseDispatchInfo.swift
@@ -5,13 +5,13 @@ import JSONWebKey
  * Data class that holds information required for dispatching responses to the verifier.
  */
 struct ResponseDispatchInfo {
-    let responseMode: String
-    let nonce: String?
-    let walletNonce: String?
-    let state: String?
-    let clientId: String
-    let responseUrl: String
-    var responseEncryptionSpecification: ResponseEncryptionSpecification?
+    public let responseMode: String
+    public var nonce: String?
+    public var walletNonce: String?
+    public let state: String?
+    public let clientId: String
+    public let responseUrl: String
+    public var responseEncryptionSpecification: ResponseEncryptionSpecification?
 }
 
 /**
@@ -22,7 +22,7 @@ struct ResponseDispatchInfo {
  * @property verifierPublicKey The verifier's public key (JWK) used for encryption
  */
 struct ResponseEncryptionSpecification {
-    let keyEncryptionAlg: EncryptionAlgorithm
-    let contentEncryptionAlg: EncryptionMethod
-    let verifierPublicKey: JWK
+    public let keyEncryptionAlg: EncryptionAlgorithm
+    public let contentEncryptionAlg: EncryptionMethod
+    public let verifierPublicKey: JWK
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -53,7 +53,13 @@ extension ResponseModeBasedHandler {
         try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: authorizationRequestParameters)
         
         let className = String(describing: ResponseModeBasedHandler.self)
-        let responseUriValue = authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as! String
+        guard let responseUriValue = authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String else {
+            throw InvalidData(
+                message: "response_uri data is not valid",
+                className: className,
+                code: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
         
         guard isValidUri(responseUriValue) else {
             throw InvalidData(

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -11,6 +11,7 @@ protocol ResponseModeBasedHandler {
                   shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification?
     
     func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String
+    func getResponseEndpoint(authorizationRequest: AuthorizationRequest) throws -> String
     
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
@@ -70,5 +71,9 @@ extension ResponseModeBasedHandler {
         }
         
         return responseUriValue
+    }
+    
+    func getResponseEndpoint(authorizationRequest: AuthorizationRequest) throws -> String {
+        return authorizationRequest.responseUri ?? ""
     }
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -10,31 +10,7 @@ protocol ResponseModeBasedHandler {
                   walletConfig: WalletConfig,
                   shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification?
     
-    func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest,
-                                   authorizationResponse: AuthorizationResponse,
-                                   url: String,
-                                   networkManager: NetworkManaging,
-                                   producerInfo: String,
-                                   recipientInfo: String,
-                                   walletConfig: WalletConfig
-    ) async throws -> NetworkResponse
-    
-    func setResponseUrl(authorizationRequestParameters: [String : Any]) throws -> String
-    
     func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String
-    
-    func getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ) throws -> [String: String]
-    
-    func getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
-    ) throws -> [String: String]
     
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
@@ -73,25 +49,6 @@ protocol ResponseModeBasedHandler {
 }
 
 extension ResponseModeBasedHandler {
-    
-    func setResponseUrl(authorizationRequestParameters: [String : Any]) throws -> String {
-        
-        try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: authorizationRequestParameters)
-        
-        let className = String(describing: ResponseModeBasedHandler.self)
-        let responseUriValue = authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as! String
-        
-        guard isValidUri(responseUriValue) else {
-            throw InvalidData(
-                message: "response_uri data is not valid",
-                className: className,
-                code: OpenID4VPErrorCodes.invalidRequest
-            )
-        }
-        
-        return responseUriValue
-    }
-    
     func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String {
         try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: authorizationRequestParameters)
         

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -4,11 +4,11 @@ import JSONWebKey
 protocol ResponseModeBasedHandler {
     func validate(clientMetadata: ClientMetadata?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification?
     
     func validate(clientMetadata: ClientMetadataDraft23?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification?
     
     func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest,
                                    authorizationResponse: AuthorizationResponse,
@@ -19,9 +19,9 @@ protocol ResponseModeBasedHandler {
                                    walletConfig: WalletConfig
     ) async throws -> NetworkResponse
     
-    func setResponseUrl(authorizationRequestParameters: [String : Any], setResponseUri: (String) -> Void) throws
+    func setResponseUrl(authorizationRequestParameters: [String : Any]) throws -> String
     
-    func getResponseEndpoint(authorizationRequest: AuthorizationRequest) throws -> String
+    func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String
     
     func getAuthorizationResponse(
             authorizationRequest: AuthorizationRequest,
@@ -40,11 +40,37 @@ protocol ResponseModeBasedHandler {
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig
     ) throws -> JWK?
+
+    /// Constructs an authorization error response body as per response mode.
+    func getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse
+    ) throws -> [String: String]
+
+    /// Sends an authorization error response to the verifier.
+    func sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse
+
+    /// Constructs an authorization response body as per response mode.
+    func getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse
+    ) throws -> [String: String]
+
+    /// Sends an authorization response to the verifier.
+    func sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse
 }
 
 extension ResponseModeBasedHandler {
     
-    func setResponseUrl(authorizationRequestParameters: [String : Any], setResponseUri: (String) -> Void) throws {
+    func setResponseUrl(authorizationRequestParameters: [String : Any]) throws -> String {
         
         try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: authorizationRequestParameters)
         
@@ -59,6 +85,23 @@ extension ResponseModeBasedHandler {
             )
         }
         
-        setResponseUri(responseUriValue)
+        return responseUriValue
+    }
+
+    func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String {
+        try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: authorizationRequestParameters)
+        
+        let className = String(describing: ResponseModeBasedHandler.self)
+        let responseUriValue = authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as! String
+        
+        guard isValidUri(responseUriValue) else {
+            throw InvalidData(
+                message: "response_uri data is not valid",
+                className: className,
+                code: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+        
+        return responseUriValue
     }
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -44,26 +44,30 @@ protocol ResponseModeBasedHandler {
     /// Constructs an authorization error response body as per response mode.
     func getAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationErrorResponse
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
     ) throws -> [String: String]
     
     /// Sends an authorization error response to the verifier.
     func sendAuthorizationError(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse
     
     /// Constructs an authorization response body as per response mode.
     func getAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationResponse
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
     ) throws -> [String: String]
     
     /// Sends an authorization response to the verifier.
     func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/ResponseModeBasedHandler.swift
@@ -24,42 +24,42 @@ protocol ResponseModeBasedHandler {
     func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String
     
     func getAuthorizationResponse(
-            authorizationRequest: AuthorizationRequest,
-            authorizationResponse: AuthorizationResponse,
-            walletNonce: String,
-            walletConfig: WalletConfig
-        ) throws -> [String: String]
-
-        func getAuthorizationErrorResponse(
-            authorizationRequest: AuthorizationRequest?,
-            authorizationResponse: AuthorizationErrorResponse,
-            walletNonce: String
-        ) throws -> [String: String]
-
+        authorizationRequest: AuthorizationRequest,
+        authorizationResponse: AuthorizationResponse,
+        walletNonce: String,
+        walletConfig: WalletConfig
+    ) throws -> [String: String]
+    
+    func getAuthorizationErrorResponse(
+        authorizationRequest: AuthorizationRequest?,
+        authorizationResponse: AuthorizationErrorResponse,
+        walletNonce: String
+    ) throws -> [String: String]
+    
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig
     ) throws -> JWK?
-
+    
     /// Constructs an authorization error response body as per response mode.
     func getAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse
     ) throws -> [String: String]
-
+    
     /// Sends an authorization error response to the verifier.
     func sendAuthorizationError(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse
-
+    
     /// Constructs an authorization response body as per response mode.
     func getAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse
     ) throws -> [String: String]
-
+    
     /// Sends an authorization response to the verifier.
     func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
@@ -87,7 +87,7 @@ extension ResponseModeBasedHandler {
         
         return responseUriValue
     }
-
+    
     func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String {
         try validateAttribute(AuthorizationRequestFieldConstants.responseUri, values: authorizationRequestParameters)
         

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -149,23 +149,26 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
     
     func getAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationErrorResponse
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
     ) throws -> [String: String] {
         let errorMap = authorizationResponse.toJsonEncodedMap()
         guard dispatchInfo.responseEncryptionSpecification != nil else {
             return errorMap
         }
         let responseParams = try JSONSerialization.data(withJSONObject: errorMap)
-        let jweHandler = try makeJWEHandler(from: dispatchInfo)
+        let recipientNonce = authorizationRequest?.nonce ?? dispatchInfo.nonce ?? ""
+        let jweHandler = try makeJWEHandler(from: dispatchInfo, recipientNonce: recipientNonce)
         return try encryptResponse(responseParams: responseParams, using: jweHandler)
     }
 
     func sendAuthorizationError(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse {
-        let requestBody = try getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        let requestBody = try getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse, authorizationRequest: authorizationRequest)
         return try await networkManager.sendHTTPRequest(
             url: dispatchInfo.responseUrl,
             method: .post,
@@ -176,19 +179,21 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
 
     func getAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationResponse
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
     ) throws -> [String: String] {
         let responseParams = try authorizationResponse.payloadData()
-        let jweHandler = try makeJWEHandler(from: dispatchInfo)
+        let jweHandler = try makeJWEHandler(from: dispatchInfo, recipientNonce: authorizationRequest.nonce)
         return try encryptResponse(responseParams: responseParams, using: jweHandler)
     }
 
     func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse {
-        let requestBody = try getAuthorizationResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        let requestBody = try getAuthorizationResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse, authorizationRequest: authorizationRequest)
         return try await networkManager.sendHTTPRequest(
             url: dispatchInfo.responseUrl,
             method: .post,
@@ -197,7 +202,7 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
         )
     }
 
-    private func makeJWEHandler(from dispatchInfo: ResponseDispatchInfo) throws -> JWEHandler {
+    private func makeJWEHandler(from dispatchInfo: ResponseDispatchInfo, recipientNonce: String) throws -> JWEHandler {
         guard let encryptionSpec = dispatchInfo.responseEncryptionSpecification else {
             throw InvalidData(
                 message: "responseEncryptionSpecification is required for response mode 'direct_post.jwt'",
@@ -209,7 +214,7 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
             keyEncryptionAlgorithm: encryptionSpec.keyEncryptionAlg.rawValue,
             publicKey: encryptionSpec.verifierPublicKey,
             producerInfo: dispatchInfo.walletNonce ?? "",
-            recipientInfo: dispatchInfo.nonce ?? ""
+            recipientInfo: recipientNonce
         )
     }
 

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -7,7 +7,7 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
     
     func validate(clientMetadata: ClientMetadataDraft23?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws {
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
         guard clientMetadata != nil else {
             throw InvalidData(
                   message: "client_metadata must be present for given response mode",
@@ -32,12 +32,17 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
         }
 
         try validateEncryption(verifierEncryptionAlg: [encryptedResponseAlgorithm], verifierEnc: enc, jwks: jwks, walletConfig: walletConfig, shouldValidate: shouldValidateWithWalletMetadata)
-        _ = try getEncryptionKey(jwks, [encryptedResponseAlgorithm])
+        let encryptionKey = try getEncryptionKey(jwks, [encryptedResponseAlgorithm])
+        return ResponseEncryptionSpecification(
+            keyEncryptionAlg: EncryptionAlgorithm(rawValue: encryptedResponseAlgorithm)!,
+            contentEncryptionAlg: EncryptionMethod(rawValue: enc)!,
+            verifierPublicKey: encryptionKey
+        )
     }
     
     func validate(clientMetadata: ClientMetadata?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws {
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
         guard clientMetadata != nil else {
             throw InvalidData(
                   message: "client_metadata must be present for given response mode",
@@ -62,7 +67,24 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
         
         let verifierEncrptionAlgorithms = jwks.keys.compactMap { $0.algorithm }
         try validateEncryption(verifierEncryptionAlg: verifierEncrptionAlgorithms, verifierEnc: enc, jwks: jwks, walletConfig: walletConfig, shouldValidate: shouldValidateWithWalletMetadata)
-        _ = try getEncryptionKey(jwks, walletConfig.authorizationEncryptionAlgValuesSupported?.compactMap { $0.rawValue } ?? [EncryptionAlgorithm.ecdhES.rawValue])
+        let encryptionKey = try getEncryptionKey(jwks, walletConfig.authorizationEncryptionAlgValuesSupported?.compactMap { $0.rawValue } ?? [EncryptionAlgorithm.ecdhES.rawValue])
+        
+        guard let clientEncValues = clientMetadata?.encryptedResponseEncValuesSupported, !clientEncValues.isEmpty else {
+            throw InvalidData(message: "Unsupported content encryption algorithm", className: className)
+        }
+        let walletEncValues = walletConfig.authorizationEncryptionEncValuesSupported?.compactMap { $0.rawValue } ?? [EncryptionMethod.a256GCM.rawValue]
+        guard let contentEncryptionAlgorithm = walletEncValues.first(where: { clientEncValues.contains($0) }) else {
+            throw InvalidData(message: "Unsupported content encryption algorithm", className: className)
+        }
+        guard let verifierPublicKeyAlgorithm = encryptionKey.algorithm else {
+            throw InvalidData(message: "Algorithm must be specified for the encryption key in jwks", className: className)
+        }
+        
+        return ResponseEncryptionSpecification(
+            keyEncryptionAlg: EncryptionAlgorithm(rawValue: verifierPublicKeyAlgorithm)!,
+            contentEncryptionAlg: EncryptionMethod(rawValue: contentEncryptionAlgorithm)!,
+            verifierPublicKey: encryptionKey
+        )
     }
     
     private func validateEncryption(verifierEncryptionAlg: [String], verifierEnc: Any, jwks: JWKSet, walletConfig: WalletConfig, shouldValidate: Bool) throws {

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -213,7 +213,7 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
             contentEncryptionAlgorithm: encryptionSpec.contentEncryptionAlg.rawValue,
             keyEncryptionAlgorithm: encryptionSpec.keyEncryptionAlg.rawValue,
             publicKey: encryptionSpec.verifierPublicKey,
-            producerInfo: dispatchInfo.walletNonce ?? "",
+            producerInfo: dispatchInfo.walletNonce ?? NonceProvider().generateNonce(),
             recipientInfo: recipientNonce
         )
     }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -108,37 +108,6 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
         }
     }
     
-    func getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ) throws -> [String: String] {
-        let responseParams = try authorizationResponse.payloadData()
-        return try encryptResponse(
-            authorizationRequest: authorizationRequest,
-            responseParams: responseParams,
-            walletNonce: walletNonce,
-            walletConfig: walletConfig
-        )
-    }
-    
-    func sendAuthorizationResponse(authorizationRequest: AuthorizationRequest, authorizationResponse: AuthorizationResponse, url: String, networkManager: any NetworkManaging, producerInfo: String,
-                                   recipientInfo: String, walletConfig: WalletConfig) async throws -> NetworkResponse {
-        let requestBody = try getAuthorizationResponse(authorizationRequest: authorizationRequest, authorizationResponse: authorizationResponse, walletNonce: producerInfo, walletConfig: walletConfig)
-        let response = try await networkManager.sendHTTPRequest(url: url, method: .post, bodyParams: requestBody, headers: [Header.contentType.rawValue : ContentTypes.applicationFormUrlEncoded.rawValue])
-
-        return response
-    }
-    
-    func getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
-    ) throws -> [String: String] {
-        return authorizationResponse.toJsonEncodedMap()
-    }
-    
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig
@@ -218,41 +187,9 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
         )
     }
 
-    private func encryptResponse(
-        authorizationRequest: AuthorizationRequest,
-        responseParams: Data,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ) throws -> [String: String] {
-        let specVersionHandler = SpecVersionHandler.from(authorizationRequest)
-        let jweHandler = try specVersionHandler.getJWEHandler(authorizationRequest: authorizationRequest, walletNonce: walletNonce, walletConfig: walletConfig, className: className)
-        return try encryptResponse(responseParams: responseParams, using: jweHandler)
-    }
-
     private func encryptResponse(responseParams: Data, using jweHandler: JWEHandler) throws -> [String: String] {
         let encryptedBody = try jweHandler.encrypt(responseParams)
         return ["response": encryptedBody]
-    }
-
-    private func validateWithWalletMetadata(verifierEncryptionAlg: [String],
-                                            verifierEnc: Any,
-                                            walletConfig: WalletConfig) throws {
-        guard let supportedEncryptionAlgorithms = walletConfig.authorizationEncryptionAlgValuesSupported?.compactMap({$0.rawValue}) else {
-            throw InvalidData(message: "authorization_encryption_alg_values_supported must be present in wallet_metadata", className: className)
-        }
-
-        guard verifierEncryptionAlg.contains(where: { supportedEncryptionAlgorithms.contains($0) }) else {
-            throw InvalidData(message: "Authorization response encryption algorithm is not supported", className: className)
-        }
-
-        guard let supportedEncryptions = walletConfig.authorizationEncryptionEncValuesSupported?.compactMap({$0.rawValue}) else {
-            throw InvalidData(message: "authorization_encryption_enc_values_supported must be present in wallet_metadata", className: className)
-        }
-
-        let verifierEncArray = (verifierEnc as? String).map { [$0] } ?? (verifierEnc as? [String]) ?? []
-        guard verifierEncArray.contains(where: { encValue in supportedEncryptions.contains(encValue) }) else {
-            throw InvalidData(message: "authorization_encrypted_response_enc is not supported", className: className)
-        }
     }
     
     private enum SpecVersionHandler {
@@ -284,32 +221,5 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
             }
         }
 
-        func getJWEHandler(authorizationRequest: AuthorizationRequest, walletNonce: String, walletConfig: WalletConfig, className: String) throws -> JWEHandler {
-            switch self {
-            case .draft23:
-                let clientMetadata = ((authorizationRequest as? AuthorizationPresentationExchangeRequest)?.clientMetadata)!
-                let verifierPublicKey = try getVerifierPublicKey(authorizationRequest: authorizationRequest, walletConfig: walletConfig, className: className)
-                return JWEHandler(contentEncryptionAlgorithm: clientMetadata.authorizationEncryptedResponseEnc!, keyEncryptionAlgorithm: clientMetadata.authorizationEncryptedResponseAlg!, publicKey: verifierPublicKey, producerInfo: walletNonce, recipientInfo: authorizationRequest.nonce)
-            case .v1:
-                guard let clientMetadata = (authorizationRequest as? AuthorizationDcqlRequest)?.clientMetadata else {
-                    throw InvalidData(message: "client_metadata must be present for given response mode", className: className)
-                }
-                guard clientMetadata.jwks != nil else {
-                    throw MissingInput(fieldPath: ["client_metadata", "jwks"], message: "", className: className)
-                }
-                guard let clientEncValues = clientMetadata.encryptedResponseEncValuesSupported, !clientEncValues.isEmpty else {
-                    throw InvalidData(message: "Unsupported content encryption algorithm", className: className)
-                }
-                let walletEncValues = walletConfig.authorizationEncryptionEncValuesSupported?.compactMap { $0.rawValue } ?? [EncryptionMethod.a256GCM.rawValue]
-                guard let contentEncryptionAlgorithm = walletEncValues.first(where: { clientEncValues.contains($0) }) else {
-                    throw InvalidData(message: "Unsupported content encryption algorithm", className: className)
-                }
-                let verifierPublicKey = try getVerifierPublicKey(authorizationRequest: authorizationRequest, walletConfig: walletConfig, className: className)
-                guard let verifierPublicKeyAlgorithm = verifierPublicKey.algorithm else {
-                    throw InvalidData(message: "Algorithm must be specified for the encryption key in jwks", className: className)
-                }
-                return JWEHandler(contentEncryptionAlgorithm: contentEncryptionAlgorithm, keyEncryptionAlgorithm: verifierPublicKeyAlgorithm, publicKey: verifierPublicKey, producerInfo: walletNonce, recipientInfo: authorizationRequest.nonce)
-            }
-        }
     }
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -33,9 +33,15 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
 
         try validateEncryption(verifierEncryptionAlg: [encryptedResponseAlgorithm], verifierEnc: enc, jwks: jwks, walletConfig: walletConfig, shouldValidate: shouldValidateWithWalletMetadata)
         let encryptionKey = try getEncryptionKey(jwks, [encryptedResponseAlgorithm])
+        guard let keyAlg = EncryptionAlgorithm(rawValue: encryptedResponseAlgorithm) else {
+            throw InvalidData(message: "Unsupported key encryption algorithm: \(encryptedResponseAlgorithm)", className: className)
+        }
+        guard let contentAlg = EncryptionMethod(rawValue: enc) else {
+            throw InvalidData(message: "Unsupported content encryption algorithm: \(enc)", className: className)
+        }
         return ResponseEncryptionSpecification(
-            keyEncryptionAlg: EncryptionAlgorithm(rawValue: encryptedResponseAlgorithm)!,
-            contentEncryptionAlg: EncryptionMethod(rawValue: enc)!,
+            keyEncryptionAlg: keyAlg,
+            contentEncryptionAlg: contentAlg,
             verifierPublicKey: encryptionKey
         )
     }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostJwtResponseModeHandler.swift
@@ -125,12 +125,72 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
             .getVerifierPublicKey(authorizationRequest: authorizationRequest, walletConfig: walletConfig, className: className)
     }
     
-    func getResponseEndpoint(authorizationRequest: AuthorizationRequest) throws -> String {
-        return try authorizationRequest.responseUri ?? {
-            throw InvalidData(message: "response_uri is required in authorization request for response mode 'direct_post.jwt'", className: className)
-        }()
+    func getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse
+    ) throws -> [String: String] {
+        let errorMap = authorizationResponse.toJsonEncodedMap()
+        guard dispatchInfo.responseEncryptionSpecification != nil else {
+            return errorMap
+        }
+        let responseParams = try JSONSerialization.data(withJSONObject: errorMap)
+        let jweHandler = try makeJWEHandler(from: dispatchInfo)
+        return try encryptResponse(responseParams: responseParams, using: jweHandler)
     }
-    
+
+    func sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        let requestBody = try getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        return try await networkManager.sendHTTPRequest(
+            url: dispatchInfo.responseUrl,
+            method: .post,
+            bodyParams: requestBody,
+            headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
+        )
+    }
+
+    func getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse
+    ) throws -> [String: String] {
+        let responseParams = try authorizationResponse.payloadData()
+        let jweHandler = try makeJWEHandler(from: dispatchInfo)
+        return try encryptResponse(responseParams: responseParams, using: jweHandler)
+    }
+
+    func sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        let requestBody = try getAuthorizationResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        return try await networkManager.sendHTTPRequest(
+            url: dispatchInfo.responseUrl,
+            method: .post,
+            bodyParams: requestBody,
+            headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
+        )
+    }
+
+    private func makeJWEHandler(from dispatchInfo: ResponseDispatchInfo) throws -> JWEHandler {
+        guard let encryptionSpec = dispatchInfo.responseEncryptionSpecification else {
+            throw InvalidData(
+                message: "responseEncryptionSpecification is required for response mode 'direct_post.jwt'",
+                className: className
+            )
+        }
+        return JWEHandler(
+            contentEncryptionAlgorithm: encryptionSpec.contentEncryptionAlg.rawValue,
+            keyEncryptionAlgorithm: encryptionSpec.keyEncryptionAlg.rawValue,
+            publicKey: encryptionSpec.verifierPublicKey,
+            producerInfo: dispatchInfo.walletNonce ?? "",
+            recipientInfo: dispatchInfo.nonce ?? ""
+        )
+    }
+
     private func encryptResponse(
         authorizationRequest: AuthorizationRequest,
         responseParams: Data,
@@ -139,6 +199,10 @@ struct DirectPostJwtResponseModeHandler : ResponseModeBasedHandler {
     ) throws -> [String: String] {
         let specVersionHandler = SpecVersionHandler.from(authorizationRequest)
         let jweHandler = try specVersionHandler.getJWEHandler(authorizationRequest: authorizationRequest, walletNonce: walletNonce, walletConfig: walletConfig, className: className)
+        return try encryptResponse(responseParams: responseParams, using: jweHandler)
+    }
+
+    private func encryptResponse(responseParams: Data, using jweHandler: JWEHandler) throws -> [String: String] {
         let encryptedBody = try jweHandler.encrypt(responseParams)
         return ["response": encryptedBody]
     }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -6,19 +6,24 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
     
     func validate(clientMetadata: ClientMetadataDraft23?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws {
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
         if (clientMetadata?.authorizationEncryptedResponseEnc != nil || clientMetadata?.authorizationEncryptedResponseAlg != nil) {
             throw InvalidData(message: "encrypted_response_enc_values_supported or authorization_encrypted_response_alg SHOULD not be present for response mode 'direct_post'", className: Self.className)
         }
+        
+        return nil
     }
     
     func validate(clientMetadata: ClientMetadata?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws {
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification?{
         if clientMetadata?.encryptedResponseEncValuesSupported != nil {
             throw InvalidData(message: "encrypted_response_enc_values_supported SHOULD not be present for response mode 'direct_post'", className: Self.className)
         }
+        
+        return nil
     }
+
     
     func getAuthorizationResponse(
         authorizationRequest: AuthorizationRequest,
@@ -62,10 +67,46 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
     ) throws -> JWK? {
         return nil
     }
-    
-    func getResponseEndpoint(authorizationRequest: AuthorizationRequest) throws -> String {
-        return try authorizationRequest.responseUri ?? {
-            throw InvalidData(message: "response_uri is required in authorization request for response mode 'direct_post'", className: Self.className)
-        }()
+
+    func getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse
+    ) throws -> [String: String] {
+        return authorizationResponse.toJsonEncodedMap()
+    }
+
+    func sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        let requestBody = try getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        return try await networkManager.sendHTTPRequest(
+            url: dispatchInfo.responseUrl,
+            method: .post,
+            bodyParams: requestBody,
+            headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
+        )
+    }
+
+    func getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse
+    ) throws -> [String: String] {
+        return try authorizationResponse.toJsonEncodedMap()
+    }
+
+    func sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        let requestBody = try getAuthorizationResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        return try await networkManager.sendHTTPRequest(
+            url: dispatchInfo.responseUrl,
+            method: .post,
+            bodyParams: requestBody,
+            headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
+        )
     }
 }

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -24,43 +24,6 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
         return nil
     }
 
-    
-    func getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ) throws -> [String: String] {
-        return try authorizationResponse.toJsonEncodedMap()
-    }
-
-    func getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
-    ) -> [String: String] {
-        return authorizationResponse.toJsonEncodedMap()
-    }
-    
-    func sendAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        url: String,
-        networkManager: any NetworkManaging,
-        producerInfo: String,
-        recipientInfo: String,
-        walletConfig: WalletConfig
-    ) async throws -> NetworkResponse {
-        let requestBody: [String: String] = try authorizationResponse.toJsonEncodedMap()
-        return try await networkManager.sendHTTPRequest(
-            url: url,
-            method: .post,
-            bodyParams: requestBody,
-            headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue]
-        )
-    }
-
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -70,7 +70,8 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
 
     func getAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationErrorResponse
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
     ) throws -> [String: String] {
         return authorizationResponse.toJsonEncodedMap()
     }
@@ -78,9 +79,10 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
     func sendAuthorizationError(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse {
-        let requestBody = try getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        let requestBody = try getAuthorizationErrorResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse, authorizationRequest: authorizationRequest)
         return try await networkManager.sendHTTPRequest(
             url: dispatchInfo.responseUrl,
             method: .post,
@@ -91,7 +93,8 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
 
     func getAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationResponse
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
     ) throws -> [String: String] {
         return try authorizationResponse.toJsonEncodedMap()
     }
@@ -99,9 +102,10 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
     func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse {
-        let requestBody = try getAuthorizationResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse)
+        let requestBody = try getAuthorizationResponse(dispatchInfo: dispatchInfo, authorizationResponse: authorizationResponse, authorizationRequest: authorizationRequest)
         return try await networkManager.sendHTTPRequest(
             url: dispatchInfo.responseUrl,
             method: .post,

--- a/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
+++ b/Sources/OpenID4VP/ResponseModeHandler/types/DirectPostResponseModeHandler.swift
@@ -8,7 +8,7 @@ struct DirectPostResponseModeHandler : ResponseModeBasedHandler {
                   walletConfig: WalletConfig,
                   shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
         if (clientMetadata?.authorizationEncryptedResponseEnc != nil || clientMetadata?.authorizationEncryptedResponseAlg != nil) {
-            throw InvalidData(message: "encrypted_response_enc_values_supported or authorization_encrypted_response_alg SHOULD not be present for response mode 'direct_post'", className: Self.className)
+            throw InvalidData(message: "authorization_encrypted_response_enc or authorization_encrypted_response_alg SHOULD not be present for response mode 'direct_post'", className: Self.className)
         }
         
         return nil

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     let mockNetworkManager: MockNetworkManager! = MockNetworkManager()
-    let mockSetResponseUri: (String) -> Void = { value in
+    let mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in
     }
     var decodedClientMetadata: ClientMetadataDraft23?
     var decodedPresentationDefinition: PresentationDefinition?
@@ -27,7 +27,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters), specVersion: .draft23) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -46,7 +46,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue1: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), isSigned: true, specVersion: .v1) as [String : Any]
         let mockAuthHandler1 = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue1,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -63,7 +63,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue2: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), isSigned: true, specVersion: .draft23) as [String : Any]
         let mockAuthHandler2 = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue2,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -93,7 +93,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -112,7 +112,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters), specVersion: .draft23) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -134,7 +134,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters), specVersion: .v1) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -163,7 +163,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
 
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -186,7 +186,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -210,7 +210,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), isSigned: true, specVersion: .v1) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -233,7 +233,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         ) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -258,7 +258,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         ]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -280,7 +280,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByValue: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), isSigned: true, specVersion: .v1) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByValue,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -311,7 +311,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl, responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -328,7 +328,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter), specVersion: .v1) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -354,7 +354,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -383,7 +383,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -415,7 +415,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -445,7 +445,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -472,7 +472,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -500,7 +500,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -528,7 +528,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -556,7 +556,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -583,7 +583,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -611,7 +611,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -642,7 +642,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -671,7 +671,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -723,7 +723,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
 
             let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
                 authorizationRequestParameters: authorizationRequestParameters,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager,
                 clientId: "mock-client-id",
@@ -753,7 +753,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -783,7 +783,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: didDocumentUrl, responseBody: didResponse)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -860,7 +860,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/verifier/get-auth-request-obj",responseBody: authorizationRequestObject)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -886,7 +886,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         mockNetworkManager.setMockResponse(for: requestUri.absoluteString, responseBody: authorizationRequestObject)
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -907,7 +907,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue.map { $0 == "presentation_definition" ? "presentation_definition_uri" : $0 } , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter), specVersion: .v1) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -973,7 +973,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters,["request_uri": "http://invalid-mock-verifier.com"]), specVersion: .v1) as [String : Any]
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParametersByReference,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -994,7 +994,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     
     func testShouldThrowErrorWhenAuthRequestsAlgObtainedByReferenceDoesNotMatchWithWalletMetadata() async {
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), specVersion: .v1) as [String : Any]
-        let mockSchemeAuthRequestHandler = MockClientIdPrefixAuthRequestHandler(authorizationRequestParameters: authorizationRequestParametersByReference, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager, clientId: didUrl, specVersion: .v1, walletConfig: walletConfig, isSignedRequestSupported: true, isUnsignedRequestSupported: true)
+        let mockSchemeAuthRequestHandler = MockClientIdPrefixAuthRequestHandler(authorizationRequestParameters: authorizationRequestParametersByReference, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager, clientId: didUrl, specVersion: .v1, walletConfig: walletConfig, isSignedRequestSupported: true, isUnsignedRequestSupported: true)
         mockSchemeAuthRequestHandler.shouldValidateWithWalletMetadata = true
         let requestUriResponse = createRequestUriResponse("ewogICJhbGciOiAiSFMyNTYiLAogICJ0eXAiOiAib2F1dGgtYXV0aHotcmVxK2p3dCIKfQ.eyJ10.SflK5c")
         mockNetworkManager.setMockResponse(for: requestUri.absoluteString,response: (responseBody: requestUriResponse.body, httpUrlResponse: requestUriResponse.httpUrlResponse))
@@ -1010,7 +1010,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     func testThrowErrorWhenClientIdSchemeIsNotSupportedAsPerWalletConfig() async {
         let  minimalWalletMetadata = createWalletConfig(clientIdPrefixesSupported: [.preRegistered])
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "redirect_uri:https://federation-verifier.example.com."], ["request_uri_method": "post"])) as [String : Any]
-        let mockSchemeAuthRequestHandler = MockClientIdPrefixAuthRequestHandler(authorizationRequestParameters: authorizationRequestParametersByReference, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager, clientId: "", specVersion: .v1, walletConfig: minimalWalletMetadata, isSignedRequestSupported: true, isUnsignedRequestSupported: true)
+        let mockSchemeAuthRequestHandler = MockClientIdPrefixAuthRequestHandler(authorizationRequestParameters: authorizationRequestParametersByReference, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager, clientId: "", specVersion: .v1, walletConfig: minimalWalletMetadata, isSignedRequestSupported: true, isUnsignedRequestSupported: true)
         mockSchemeAuthRequestHandler.shouldValidateWithWalletMetadata = true
         let requestUriResponse = createRequestUriResponse("ewogICJhbGciOiAiSFMyNTYiLAogICAgInR5cCI6ICJvYXV0aC1hdXRoei1yZXErand0Igp9.eyJ10.SflK5c")
         mockNetworkManager.setMockResponse(for: requestUri.absoluteString,response: (responseBody: requestUriResponse.body, httpUrlResponse: requestUriResponse.httpUrlResponse))
@@ -1050,7 +1050,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             
             let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
                 authorizationRequestParameters: authorizationRequestParameters,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager,
                 clientId: "mock-client-id",
@@ -1072,20 +1072,25 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     
     
 //    Fetch info for sending response (error or authorization response) to verifier
-    func testResponseUrlSetSuccessfullyForResponseModeDirectPost(){
-        let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters))  as [String : Any]
-        let expectation = expectation(description: "Handler should be called with expected parameter")
-        var responseUri: String?
-        let mockSetResponseUri: (String) -> Void = { value in
-            responseUri = value
-            expectation.fulfill()
-        }
-        
-        let clientIdPrefixBasedAuthorizationRequestHandler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(clientId: "mock-client", specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        try? clientIdPrefixBasedAuthorizationRequestHandler.setResponseUrl()
-        
-        wait(for: [expectation], timeout: 2.0)
-        XCTAssertEqual(responseUri, "https://mock-verifier.com", "Handler was called with unexpected parameter")
+    func testResponseUrlSetSuccessfullyForResponseModeDirectPost() {
+        let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValue,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)
+        ) as [String: Any]
+
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+
+        XCTAssertNoThrow(try handler.prepareDispatchInfo())
+        XCTAssertNoThrow(try handler.prepareDispatchInfo())
+        XCTAssertEqual(handler.responseDispatchInfo?.responseUrl, "https://mock-verifier.com")
     }
     
     func testFetchInfoForSendingResponseToVerifierForInvalidResponseModeThrowInvalidResponseModeError() {
@@ -1106,12 +1111,12 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(clientId: "mock-client", specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
             
-            XCTAssertThrowsError(try handler.setResponseUrl()) { error in
+            XCTAssertThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
         }
@@ -1131,7 +1136,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -1174,7 +1179,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -1208,7 +1213,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                                                                                                      specVersion: .draft23,
                                                                                                      authorizationRequestParameters: authorizationRequestParameters,
                                                                                                      walletConfig: walletConfig,
-                                                                                                     setResponseUri: mockSetResponseUri,
+                                                                                                     setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                                                      walletNonce: "mock-nonce",
                                                                                                      networkManager: mockNetworkManager
         )
@@ -1241,7 +1246,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -1249,6 +1254,57 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             await XCTAssertAsyncThrowsError(try await handler.validateAndParseRequestFields()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
+        }
+    }
+    
+    
+    func testV1ParsingOfClientMetadataThrowErrorWhenClientMetadataNotPresentAndResponseModeIsDirectPostJwt() async throws {
+        let authorizationRequestParameters = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValue.filter { $0 != AuthorizationRequestFieldConstants.clientMetadata },
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters, ["response_mode": "direct_post.jwt"])
+        ) as [String: Any]
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+
+        await XCTAssertAsyncThrowsError((try await handler.validateAndParseRequestFields())) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "client_metadata must be present for given response mode",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+    
+    // In case of response mode direct_post_jwt, client_metadata is mandatory as the response will be signed which required shared key information available in client_metadata.
+    func testParsingOfClientMetadataThrowErrorWhenClientMetadataNotPresentAndResponseModeIsDirectPostJwt() async throws {
+        let authorizationRequestParameters = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValue.filter { $0 != AuthorizationRequestFieldConstants.clientMetadata },
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters, ["response_mode": "direct_post.jwt"]),
+            specVersion: .draft23
+        ) as [String: Any]
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+
+        await XCTAssertAsyncThrowsError((try await handler.validateAndParseRequestFields())) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "client_metadata must be present for given response mode",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
         }
     }
     
@@ -1271,12 +1327,12 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
             
-            await XCTAssertAsyncThrowsError(try await handler.validateAndParseRequestFields()) { error in
+            await XCTAssertAsyncThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
         }
@@ -1301,19 +1357,19 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
             
-            await XCTAssertAsyncThrowsError(try await handler.validateAndParseRequestFields()) { error in
+            await XCTAssertAsyncThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
         }
     }
     
     
-    func testInvalidRequestFieldErrorForNonceField() async {
+    func testInvalidRequestFieldErrorForNonceField() {
         let testCases: [TestCase<[String: Any?], Void>] = [
             TestCase(input: ["nonce": "null"], expectedError: "Invalid Input: nonce value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: ["nonce": ""], expectedError: "Invalid Input: nonce value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
@@ -1332,12 +1388,12 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
             
-            await XCTAssertAsyncThrowsError(try await handler.validateAndParseRequestFields()) { error in
+            XCTAssertThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
         }
@@ -1350,7 +1406,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue.map { $0 == "presentation_definition" ? "presentation_definition_uri" : $0 } , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter, ["response_type": "vp_token id_token"]), specVersion: .v1) as [String : Any]
         mockNetworkManager.setMockResponse(for: "https://mock-verifier.com/presentation-definition",responseBody: presentationDefinition)
         
-        let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(authorizationRequestParameters: authorizationRequestParameters, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(authorizationRequestParameters: authorizationRequestParameters, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncThrowsError(try await mockAuthHandler.validateAndParseRequestFields()) { error in
             assertOpenID4VPException(error,
@@ -1363,7 +1419,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     func testShouldThrowErrorWhenInvalidClientMetadataIsProvided() async{
         let authorizationRequestParameters: [String : Any] = mergeMaps(resquestUriResponseData,["client_metadata": "{}"])
         let clientIdPrefixBasedAuthorizationRequestHandler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(clientId: "mock-client",
-                                                                                                                     specVersion: .v1,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+                                                                                                                     specVersion: .v1,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
         
         clientIdPrefixBasedAuthorizationRequestHandler.setSpecVersionHandler(.v1)
         await XCTAssertAsyncThrowsError(try await clientIdPrefixBasedAuthorizationRequestHandler.validateAndParseRequestFields()) { error in
@@ -1394,7 +1450,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         let authorizationRequestParameters: [String: Any] = mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter, [AuthorizationRequestFieldConstants.transactionData: ["foo": "bar"]])
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -1432,7 +1488,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
 
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: didUrl,
@@ -1472,7 +1528,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
 
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "mock-client-id",
@@ -1505,7 +1561,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
 
         let mockAuthHandler = MockClientIdPrefixAuthRequestHandler(
             authorizationRequestParameters: authorizationRequestParameters,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager,
             clientId: "redirect_uri:https://mock-verifier.com",
@@ -1545,7 +1601,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -1577,7 +1633,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -1604,7 +1660,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -1621,7 +1677,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             specVersion: .draft23,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -1643,7 +1699,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
@@ -1089,7 +1089,6 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         )
 
         XCTAssertNoThrow(try handler.prepareDispatchInfo())
-        XCTAssertNoThrow(try handler.prepareDispatchInfo())
         XCTAssertEqual(handler.responseDispatchInfo?.responseUrl, "https://mock-verifier.com")
     }
 
@@ -1353,13 +1352,14 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         ) as [String: Any]
         let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
             clientId: "mock-client",
-            specVersion: .v1,
+            specVersion: .draft23,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
             setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
+        handler.setSpecVersionHandler(.draft23)
 
         await XCTAssertAsyncThrowsError((try await handler.validateAndParseRequestFields())) { error in
             assertOpenID4VPException(
@@ -1371,7 +1371,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     }
     
     
-    func testInvalidRequestFieldErrorForStateField() async {
+    func testInvalidRequestFieldErrorForStateField() {
         let testCases: [TestCase<[String: Any], Void>] = [
             TestCase(input: ["state": "null"], expectedError: "Invalid Input: state value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: ["state": ""], expectedError: "Invalid Input: state value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
@@ -1394,14 +1394,14 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                 networkManager: mockNetworkManager
             )
             
-            await XCTAssertAsyncThrowsError(try handler.prepareDispatchInfo()) { error in
+            XCTAssertThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
         }
     }
     
     
-    func testInvalidRequestFieldErrorForResponseModeField() async {
+    func testInvalidRequestFieldErrorForResponseModeField() {
         let testCases: [TestCase<[String: Any], Void>] = [
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "null"], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: ""], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
@@ -1424,7 +1424,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
                 networkManager: mockNetworkManager
             )
             
-            await XCTAssertAsyncThrowsError(try handler.prepareDispatchInfo()) { error in
+            XCTAssertThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
         }
@@ -1458,6 +1458,32 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             XCTAssertThrowsError(try handler.prepareDispatchInfo()) { error in
                 assertOpenID4VPException(error, expectedMessage: testCase.expectedError!, expectedCode: testCase.expectedCode!)
             }
+        }
+    }
+    
+    func testPrepareDispatchInfoThrowsWhenNonceIsNonStringType() {
+        var authorizationRequestParameters = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValue,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)
+        ) as [String: Any]
+        authorizationRequestParameters["nonce"] = 12345
+
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+
+        XCTAssertThrowsError(try handler.prepareDispatchInfo()) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Invalid Input: nonce value cannot be empty or null",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
         }
     }
     

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
@@ -1092,6 +1092,67 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         XCTAssertNoThrow(try handler.prepareDispatchInfo())
         XCTAssertEqual(handler.responseDispatchInfo?.responseUrl, "https://mock-verifier.com")
     }
+
+    func testPrepareDispatchInfoSetsExpectedDispatchInfoFields() throws {
+        let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValue,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)
+        ) as [String: Any]
+
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+
+        try handler.prepareDispatchInfo()
+        let dispatchInfo = try XCTUnwrap(handler.responseDispatchInfo)
+        XCTAssertEqual(dispatchInfo.responseMode, ResponseMode.directPost.rawValue)
+        XCTAssertEqual(dispatchInfo.nonce, authorizationRequestParameters[AuthorizationRequestFieldConstants.nonce] as? String)
+        XCTAssertEqual(dispatchInfo.state, authorizationRequestParameters[AuthorizationRequestFieldConstants.state] as? String)
+        XCTAssertEqual(dispatchInfo.clientId, "mock-client")
+        XCTAssertEqual(dispatchInfo.walletNonce, "mock-nonce")
+        XCTAssertEqual(dispatchInfo.responseUrl, authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String)
+        XCTAssertNil(dispatchInfo.responseEncryptionSpecification)
+    }
+
+    func testValidateAndParseRequestFieldsPopulatesDispatchInfoWithEncryptionSpecification() async throws {
+        let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(
+            paramList: authRequestWithPreRegisteredByValue,
+            requestParams: mergeMaps(
+                authorizationRequestParamsWithValue,
+                preRegisteredSchemeClientIdParameters,
+                [AuthorizationRequestFieldConstants.responseMode: ResponseMode.directPostJwt.rawValue]
+            ),
+            specVersion: .v1
+        ) as [String: Any]
+
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+        handler.setSpecVersionHandler(.v1)
+
+        try handler.prepareDispatchInfo()
+        await XCTAssertAsyncNoThrowsError(try await handler.validateAndParseRequestFields())
+
+        let dispatchInfo = try XCTUnwrap(handler.responseDispatchInfo)
+        let encryptionSpec = try XCTUnwrap(dispatchInfo.responseEncryptionSpecification)
+        XCTAssertEqual(dispatchInfo.responseMode, ResponseMode.directPostJwt.rawValue)
+        XCTAssertEqual(dispatchInfo.responseUrl, authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String)
+        XCTAssertEqual(encryptionSpec.keyEncryptionAlg.rawValue, "ECDH-ES")
+        XCTAssertEqual(encryptionSpec.contentEncryptionAlg.rawValue, "A256GCM")
+        XCTAssertEqual(encryptionSpec.verifierPublicKey.publicKeyUse, .encryption)
+    }
     
     func testFetchInfoForSendingResponseToVerifierForInvalidResponseModeThrowInvalidResponseModeError() {
         let testCases: [TestCase<[String: String?], Void>] = [

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
@@ -1096,9 +1096,10 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
     func testFetchInfoForSendingResponseToVerifierForInvalidResponseModeThrowInvalidResponseModeError() {
         let testCases: [TestCase<[String: String?], Void>] = [
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "fragment"], expectedError: "Given response_mode - fragment is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
-            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: ""], expectedError: "Given response_mode -  is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
-            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "nil"], expectedError: "Given response_mode - nil is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
-            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "null"], expectedError: "Given response_mode - null is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest),
+            // Empty string, "nil" string, and "null" string are caught by validateAttribute before reaching ResponseModeBasedHandlerFactory
+            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: ""], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
+            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "nil"], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
+            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "null"], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: nil], expectedError: "Given response_mode - nil is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest)
         ]
         

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/ClientIdPrefixBasedAuthorizationRequestTests.swift
@@ -1119,6 +1119,29 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
         XCTAssertNil(dispatchInfo.responseEncryptionSpecification)
     }
 
+    func testPrepareDispatchInfoDefaultsToDirectPostWhenResponseModeIsAbsent() throws {
+        // paramList without "response_mode" so the key is absent from authorizationRequestParameters
+        let paramListWithoutResponseMode = authRequestWithPreRegisteredByValue.filter { $0 != AuthorizationRequestFieldConstants.responseMode }
+        let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(
+            paramList: paramListWithoutResponseMode,
+            requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)
+        ) as [String: Any]
+
+        let handler = ClientIdPrefixBasedAuthorizationRequestHandlerBaseClass(
+            clientId: "mock-client",
+            specVersion: .v1,
+            authorizationRequestParameters: authorizationRequestParameters,
+            walletConfig: walletConfig,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
+            walletNonce: "mock-nonce",
+            networkManager: mockNetworkManager
+        )
+
+        try handler.prepareDispatchInfo()
+        let dispatchInfo = try XCTUnwrap(handler.responseDispatchInfo)
+        XCTAssertEqual(dispatchInfo.responseMode, ResponseMode.directPost.rawValue)
+    }
+
     func testValidateAndParseRequestFieldsPopulatesDispatchInfoWithEncryptionSpecification() async throws {
         let authorizationRequestParameters: [String: Any] = createAuthorizationRequest(
             paramList: authRequestWithPreRegisteredByValue,
@@ -1159,8 +1182,7 @@ final class ClientIdPrefixBasedAuthorizationRequestTests : XCTestCase {
             // Empty string, "nil" string, and "null" string are caught by validateAttribute before reaching ResponseModeBasedHandlerFactory
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: ""], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
             TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "nil"], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
-            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "null"], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest),
-            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: nil], expectedError: "Given response_mode - nil is not supported", expectedCode: OpenID4VPErrorCodes.invalidRequest)
+            TestCase(input: [AuthorizationRequestFieldConstants.responseMode: "null"], expectedError: "Invalid Input: response_mode value cannot be empty or null", expectedCode: OpenID4VPErrorCodes.invalidRequest)
         ]
         
         for testCase in testCases {

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/MockClientIdPrefixAuthRequestHandler.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/MockClientIdPrefixAuthRequestHandler.swift
@@ -12,7 +12,7 @@ class MockClientIdPrefixAuthRequestHandler: ClientIdPrefixBasedAuthorizationRequ
     var specVersionAndVPRequestMatch: Bool = true
     
     init(authorizationRequestParameters: [String: Any],
-         setResponseUri: @escaping (String) -> Void,
+         setResponseDispatchInfo: @escaping (ResponseDispatchInfo) -> Void,
          walletNonce: String,
          networkManager: NetworkManaging,
          clientId: String = "mock-client",
@@ -32,7 +32,7 @@ class MockClientIdPrefixAuthRequestHandler: ClientIdPrefixBasedAuthorizationRequ
                    specVersion: specVersion,
                    authorizationRequestParameters: authorizationRequestParameters,
                    walletConfig: walletConfig,
-                   setResponseUri: setResponseUri,
+                   setResponseDispatchInfo: setResponseDispatchInfo,
                    walletNonce: walletNonce,
                    networkManager: networkManager)
         delegate = self

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests.swift
@@ -77,8 +77,8 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
         
         // Spec Version Draft 23
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
-        _ = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.draft23]!)) as [String : Any]
-        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let authorizationRequestParametersByReferenceDraft23: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.draft23]!), specVersion: .draft23) as [String : Any]
+        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .draft23 ,authorizationRequestParameters: authorizationRequestParametersByReferenceDraft23, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
 
         await XCTAssertNoThrowAndVerifyAsync(try await didSchemeAuthRequestHandler2.extractPublicKey(keyId: JWSUtil.publicKeyId, algorithm: "EdDSA")){ publicKey in
             assertPublicKey(expectedBase64Encoded: "+Fy3lMapzR3wpaYNCFq29GDEn/NoR3pBsc511q1Cxqw=", actualKey: publicKey)

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase {
     let mockNetworkManager: MockNetworkManager! = MockNetworkManager()
     let decentralizedIdentifierClientId: String = ClientIdPrefix.decentralizedIdentifier.rawValue + ":"+didUrl
-    let mockSetResponseUri: (String) -> Void = { value in
+    let mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in
     }
     
     let requestUri: URL = URL(string: "https://mock-verifier.com/verifier/get-auth-request-obj")!
@@ -20,14 +20,14 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
     
     func testReturnFalseForAuthorizationRequestByReferenceSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter)) as [String : Any]
-        let handler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let handler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertTrue(handler.isSignedRequestSupported(), "did client_id_prefix should support request by reference")
     }
     
     func testReturnFalseForAuthorizationRequestByValueSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter)) as [String : Any]
-        let handler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let handler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertFalse(handler.isUnsignedRequestSupported(), "did client_id_prefix should not support request by value")
     }
@@ -37,14 +37,14 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
         // Spec Version 1.0 expects client ID decentralized_identifier:did:...
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let authorizationRequestParametersByReference1: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.draft23]!), specVersion: .v1) as [String : Any]
-        let didSchemeAuthRequestHandler1 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference1, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler1 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference1, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         
         XCTAssertFalse(didSchemeAuthRequestHandler1.confirmSpecVersionIdentifiedFromRequest(), "handler should return false when client_id does not align with spec version")
         
         // Spec version draft 23 expects Client ID did:...
         let authorizationRequestParametersByReference2: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), specVersion: .draft23) as [String : Any]
-        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .draft23 ,authorizationRequestParameters: authorizationRequestParametersByReference2, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .draft23 ,authorizationRequestParameters: authorizationRequestParametersByReference2, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertFalse(didSchemeAuthRequestHandler2.confirmSpecVersionIdentifiedFromRequest(), "handler should return false when client_id does not align with spec version")
     }
@@ -53,14 +53,14 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
         // Spec Version 1.0 expects client ID decentralized_identifier:did:...
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let authorizationRequestParametersByReference1: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!), specVersion: .v1) as [String : Any]
-        let didSchemeAuthRequestHandler1 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference1, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler1 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference1, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         
         XCTAssertTrue(didSchemeAuthRequestHandler1.confirmSpecVersionIdentifiedFromRequest(), "handler should return true when client_id does align with spec version")
         
         // Spec version draft 23 expects Client ID did:...
         let authorizationRequestParametersByReference2: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.draft23]!), specVersion: .draft23) as [String : Any]
-        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .draft23 ,authorizationRequestParameters: authorizationRequestParametersByReference2, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .draft23 ,authorizationRequestParameters: authorizationRequestParametersByReference2, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertTrue(didSchemeAuthRequestHandler2.confirmSpecVersionIdentifiedFromRequest(), "handler should return true when client_id does align with spec version")
     }
@@ -69,7 +69,7 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
         // Spec Version 1.0
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!)) as [String : Any]
-        let didSchemeAuthRequestHandler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
 
         await XCTAssertNoThrowAndVerifyAsync(try await didSchemeAuthRequestHandler.extractPublicKey(keyId: JWSUtil.publicKeyId, algorithm: "EdDSA")){ publicKey in
             assertPublicKey(expectedBase64Encoded: "+Fy3lMapzR3wpaYNCFq29GDEn/NoR3pBsc511q1Cxqw=", actualKey: publicKey)
@@ -78,7 +78,7 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
         // Spec Version Draft 23
         mockNetworkManager.setMockResponse(for: didDocumentUrl,responseBody: didResponse)
         _ = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.draft23]!)) as [String : Any]
-        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler2 = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: didUrl, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
 
         await XCTAssertNoThrowAndVerifyAsync(try await didSchemeAuthRequestHandler2.extractPublicKey(keyId: JWSUtil.publicKeyId, algorithm: "EdDSA")){ publicKey in
             assertPublicKey(expectedBase64Encoded: "+Fy3lMapzR3wpaYNCFq29GDEn/NoR3pBsc511q1Cxqw=", actualKey: publicKey)
@@ -87,7 +87,7 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
 
     func testShouldThrowErrorWhenAuthRequestObtainedByReferenceDoesNotContainJWTContentTypeInHeader() async {
         let authorizationRequestParametersByReference: [String : Any] = createAuthorizationRequest(paramList: authRequestParamsByReference , requestParams: mergeMaps(authorizationRequestParamsWithValue, DidSchemeClientIdParameters[.v1]!)) as [String : Any]
-        let didSchemeAuthRequestHandler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let didSchemeAuthRequestHandler = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParametersByReference, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         mockNetworkManager.setMockResponse(for: requestUri.absoluteString, error: NetworkRequestException.networkRequestFailed(message: "Response does not match any acceptable types"))
 
         await XCTAssertAsyncThrowsError(try await didSchemeAuthRequestHandler.fetchAuthorizationRequest()) { error in
@@ -102,7 +102,7 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "mock-client",
         ])) as [String : Any]
-        let didScheme = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let didScheme = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         let expectedWalletMetadata : [String: Any] = [
             "authorization_encryption_alg_values_supported": ["ECDH-ES"],
             "request_object_signing_alg_values_supported": ["EdDSA"],
@@ -130,7 +130,7 @@ class DecentralizedIdentifierPrefixAuthorizationRequestHandlerTests : XCTestCase
 
         let walletConfig = createWalletConfig(requestObjectSigningAlgValuesSupported: nil)
 
-        let didScheme = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let didScheme = DecentralizedIdentifierPrefixAuthorizationRequestHandler(clientId: decentralizedIdentifierClientId, specVersion: .v1 ,authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
 
         await XCTAssertAsyncThrowsError(try didScheme.getWalletMetadata(walletConfig: walletConfig)) { error in
             assertOpenID4VPException(error,

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/PreRegisteredClientIdPrefixAuthorizationRequestTests.swift
@@ -7,7 +7,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     let mockNetworkManager: MockNetworkManager! = MockNetworkManager()
     let mockNetworkManagerReal: NetworkManager! = NetworkManager()
     let clientId: String = "mock-client"
-    let mockSetResponseUri: (String) -> Void = { value in
+    let mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in
     }
     
     let requestUriResponse: String = createAuthorizationRequestObject(clientIdPrefix: .preRegistered, authorizationRequestParams: mergeMaps(authorizationRequestParamsWithValue,[
@@ -27,7 +27,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "untrusted-mock-client",
         ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-mock-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-mock-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.validateClientId()) { error in
             assertOpenID4VPException(
@@ -41,7 +41,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testThrowExceptionWhenTrustedVerifiersListIsEmpty(){
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "other-mock-client","response_uri": "https://mock-verifier.com"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "other-mock-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "other-mock-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.validateClientId()) { error in
             assertOpenID4VPException(
@@ -55,9 +55,9 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     func testThrowErrorWhenBothResponseUriAndRedirectUriPresentForDirectPost() {
         var authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
         authorizationRequestParameters[AuthorizationRequestFieldConstants.redirectUri] = "https://mock-verifier.com"
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
 
-        XCTAssertThrowsError(try preRegistered.setResponseUrl()) { error in
+        XCTAssertThrowsError(try preRegistered.prepareDispatchInfo()) { error in
             assertOpenID4VPException(
                 error,
                 expectedMessage: "redirect_uri should not be present for given response_mode",
@@ -70,7 +70,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
 
     func testReturnTrueForAuthorizationRequestByReferenceSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertTrue(preRegistered.isSignedRequestSupported(), "Pre-registered client id scheme should support authorization request by reference")
     }
@@ -78,13 +78,13 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testisUnsignedRequestSupported_validatePreregisteredVerifierFalse_returnsTrue() {
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "mock-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(validatePreregisteredVerifier: false), setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(validatePreregisteredVerifier: false), setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         XCTAssertTrue(try preRegistered.isUnsignedRequestSupported(), "Should return true when validatePreregisteredVerifier is false")
     }
     
     func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdNotAvailable_throwsError() {
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "untrusted-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertThrowsError(try preRegistered.isUnsignedRequestSupported()) { error in
             assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
@@ -94,14 +94,14 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdAvailable_allowUnsignedFalse_returnsFalse() {
         let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], allowUnsignedRequest: false)]
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "mock-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         XCTAssertFalse(try preRegistered.isUnsignedRequestSupported(), "Should return false when allowUnsignedRequest is false")
     }
     
     func testisUnsignedRequestSupported_validatePreregisteredVerifierTrue_clientIdAvailable_allowUnsignedTrue_returnsTrue() {
         let trustedVerifiers = [Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"], allowUnsignedRequest: true)]
         let authorizationRequestParameters: [String : Any] = [AuthorizationRequestFieldConstants.clientId: "mock-client"]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         XCTAssertTrue(try preRegistered.isUnsignedRequestSupported(), "Should return true when allowUnsignedRequest is true")
     }
     
@@ -114,7 +114,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let trustedVerifiersWithoutClientMetadata = [
             Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"])
         ]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiersWithoutClientMetadata),setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiersWithoutClientMetadata),setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncNoThrowsError(try await preRegistered.validateAndParseRequestFields(), "Error should not happen when client_metadata is not known to wallet but provided in authorization request")
     }
@@ -156,7 +156,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             "client_id": "mock-client",
         ]), specVersion: .draft23) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         try? await preRegistered.fetchAuthorizationRequest()
         
@@ -167,7 +167,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "mock-client",
         ])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         let expectedWalletMetadata = [
             "authorization_encryption_alg_values_supported": ["ECDH-ES"],
@@ -195,7 +195,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             AuthorizationRequestFieldConstants.clientId: "mock-client",
         ])) as [String : Any]
         
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         await XCTAssertAsyncThrowsError(try preRegistered.getWalletMetadata(walletConfig: walletConfig)) { error in
             assertOpenID4VPException(error,
@@ -207,7 +207,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testExtractPublicKeyThrowErrorWhenPreRegisteredClientNotAvailable() async throws {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue, requestParams: mergeMaps(authorizationRequestParamsWithValue, ["client_id": "untrusted-client"])) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: "untrusted-client", specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "ECDSA")){ error in
             assertOpenID4VPException(error, expectedMessage: "Verifier is not trusted by the wallet", expectedCode: OpenID4VPErrorCodes.invalidClient)
@@ -220,7 +220,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             Verifier(clientId: "mock-client", responseUris: ["https://mock-verifier.com"])
         ]
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: createWalletConfig(trustedVerifiers: trustedVerifiers),setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         
         await XCTAssertAsyncThrowsError(try await preRegistered.extractPublicKey(keyId: "ed-key2", algorithm: "EdDSA")){ error in
@@ -230,7 +230,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
     
     func testClientIdPrefixShouldReturnPreRegistered(){
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, preRegisteredSchemeClientIdParameters)) as [String : Any]
-        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig,setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertEqual(preRegistered.clientIdPrefix(), ClientIdPrefix.preRegistered.rawValue, "clientIdPrefix should return pre-registered")
     }
@@ -245,7 +245,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -265,7 +265,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: createWalletConfig(trustedVerifiers: [trustedVerifier]),
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -286,7 +286,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: createWalletConfig(trustedVerifiers: [trustedVerifier]),
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -319,7 +319,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
         let preRegistered = PreRegisteredSchemeAuthorizationRequestHandler(clientId: clientId, specVersion: .v1,
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: createWalletConfig(trustedVerifiers: [trustedVerifier]),
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -359,7 +359,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -377,7 +377,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -395,7 +395,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
                                                                            
                                                                            authorizationRequestParameters: authorizationRequestParameters,
                                                                            walletConfig: walletConfig,
-                                                                           setResponseUri: mockSetResponseUri,
+                                                                           setResponseDispatchInfo: mockSetResponseDispatchInfo,
                                                                            walletNonce: "mock-nonce",
                                                                            networkManager: mockNetworkManager!
         )
@@ -417,7 +417,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: createWalletConfig(validatePreregisteredVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -434,7 +434,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -451,7 +451,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -474,7 +474,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -496,7 +496,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -519,7 +519,7 @@ class PreRegisteredClientIdPrefixTests : XCTestCase {
             specVersion: .v1,
             authorizationRequestParameters: authorizationRequestParameters,
             walletConfig: createWalletConfig(trustedVerifiers: [Verifier(clientId: clientId, responseUris: ["https://some-other-verifier.com"])]),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestHandler/types/RedirectUriSchemeAuthRequestHandlerTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     let mockNetworkManager: MockNetworkManager! = MockNetworkManager()
-    let mockSetResponseUri: (String) -> Void = { value in
+    let mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in
     }
     let requestUri: URL = URL(string: "https://mock-verifier.com/verifier/get-auth-request-obj")!
     let clientId: String = "redirect_uri:https://mock-verifier.com"
@@ -25,14 +25,14 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     
     func testReturnFalseForAuthorizationRequestByReferenceSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest( paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter)) as [String : Any]
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertFalse(handler.isSignedRequestSupported(), "redirect_uri client_id_prefix should not support request by reference")
     }
     
     func testReturnTrueForAuthorizationRequestByValueSupport() {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter)) as [String : Any]
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         XCTAssertTrue(handler.isUnsignedRequestSupported(), "redirect_uri client_id_prefix should support request by value")
     }
@@ -41,7 +41,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     
     func testThrowNoErrorForValidAuthorizationRequestWhileValidateAndParseRequestFields() async {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter), addEncryptionClientMetadataParams: false) as [String : Any]
-        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncNoThrowsError(try await redirectUriSchemeAuthRequestHandler.validateAndParseRequestFields())
     }
@@ -49,9 +49,9 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     func testThrowErrorWhenBothResponseUriAndRedirectUriPresentForDirectPost() {
         var authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter), addEncryptionClientMetadataParams: false) as [String : Any]
         authorizationRequestParameters[AuthorizationRequestFieldConstants.redirectUri] = "https://mock-verifier.com"
-        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
 
-        XCTAssertThrowsError(try redirectUriSchemeAuthRequestHandler.setResponseUrl()) { error in
+        XCTAssertThrowsError(try redirectUriSchemeAuthRequestHandler.prepareDispatchInfo()) { error in
             assertOpenID4VPException(error,
                                      expectedMessage: "redirect_uri should not be present for given response_mode",
                                      expectedCode: OpenID4VPErrorCodes.invalidRequest
@@ -61,7 +61,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
 
     func testThrowErrorWhenAuthorizationRequestObjectClientIdIsNotMatchingWithRequestParameterClientIdInDirectPostResponseMode() async {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithRedirectUriByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter, [AuthorizationRequestFieldConstants.responseMode: "fragment","redirect_uri": "http://invalid-mock-verifier.com"])) as [String : Any]
-        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let redirectUriSchemeAuthRequestHandler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncThrowsError(try await redirectUriSchemeAuthRequestHandler.validateAndParseRequestFields()) { error in
             assertOpenID4VPException(error,
@@ -75,7 +75,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, [
             AuthorizationRequestFieldConstants.clientId: "mock-client",
         ])) as [String : Any]
-        let redirectScheme = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
+        let redirectScheme = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager!)
         
         let expectedWalletMetadata : [String: Any] = [
             "authorization_encryption_alg_values_supported": ["ECDH-ES"],
@@ -98,7 +98,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
     
     func testThrowErrorWhenExtractPublicKeyIsInvoked() async {
         let authorizationRequestParameters: [String : Any] = createAuthorizationRequest(paramList: authRequestWithPreRegisteredByValue , requestParams: mergeMaps(authorizationRequestParamsWithValue, redirectUriSchemeClientIdParameter)) as [String : Any]
-        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1, authorizationRequestParameters: authorizationRequestParameters, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         await XCTAssertAsyncThrowsError(try await handler.extractPublicKey(keyId: nil, algorithm: "edDsa")) { error in
             assertOpenID4VPException(error,
@@ -126,7 +126,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -161,7 +161,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: params,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -188,7 +188,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -210,7 +210,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -232,7 +232,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -265,7 +265,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: params,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -293,7 +293,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -318,7 +318,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
         let handler = RedirectUriPrefixAuthorizationRequestHandler(clientId: clientId,specVersion: .v1,
             authorizationRequestParameters: params,
             walletConfig: walletConfig,
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -339,7 +339,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -366,7 +366,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -389,7 +389,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: authorizationRequestParameters,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -431,7 +431,7 @@ class RedirectUriSchemeAuthRequestHandlerTests : XCTestCase {
                 specVersion: .v1,
                 authorizationRequestParameters: params,
                 walletConfig: walletConfig,
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/AuthorizationRequestTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class AuthorizationRequestTests: XCTestCase {
     
     private var mockNetworkManager: MockNetworkManager!
-    private var mockSetResponseUri: (String) -> Void = { _ in }
+    private var mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in }
     private var trustedVerifiers: [Verifier]!
     
     override func setUp() {
@@ -24,7 +24,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -41,7 +41,7 @@ final class AuthorizationRequestTests: XCTestCase {
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: urlWithoutClientId,
                 walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -67,7 +67,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -87,7 +87,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -106,7 +106,7 @@ final class AuthorizationRequestTests: XCTestCase {
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 authRequest: authRequest,
                 walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -126,7 +126,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -141,7 +141,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: testValidUrlEncodedVPRequestWithResponseUri,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -171,7 +171,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: urlEncoded,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -198,7 +198,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             urlEncodedAuthorizationRequest: urlEncoded,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -222,7 +222,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -250,7 +250,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -275,7 +275,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -298,7 +298,7 @@ final class AuthorizationRequestTests: XCTestCase {
         let request = try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
             authRequest: authRequest,
             walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-            setResponseUri: mockSetResponseUri,
+            setResponseDispatchInfo: mockSetResponseDispatchInfo,
             walletNonce: "mock-nonce",
             networkManager: mockNetworkManager
         )
@@ -315,7 +315,7 @@ final class AuthorizationRequestTests: XCTestCase {
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: malformedUrl,
                 walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -347,7 +347,7 @@ final class AuthorizationRequestTests: XCTestCase {
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 urlEncodedAuthorizationRequest: urlEncoded,
                 walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )
@@ -364,7 +364,7 @@ final class AuthorizationRequestTests: XCTestCase {
             try await AuthorizationRequest.validateAndCreateAuthorizationRequest(
                 authRequest: authRequest,
                 walletConfig: WalletConfig(trustedVerifiers: trustedVerifiers, validateTrustedVerifier: false),
-                setResponseUri: mockSetResponseUri,
+                setResponseDispatchInfo: mockSetResponseDispatchInfo,
                 walletNonce: "mock-nonce",
                 networkManager: mockNetworkManager
             )

--- a/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataUtilTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/ClientMetadata/ClientMetadataUtilTests.swift
@@ -58,18 +58,6 @@ final class ClientMetadataUtilTests: XCTestCase {
         }
     }
     
-    // In case of response mode direct_post_jwt, client_metadata is mandatory as the response will be signed which required shared key information available in client_metadata.
-    func testParsingOfClientMetadataThrowErrorWhenClientMetadataNotPresentAndResponseModeIsDirectPostJwt() throws {
-        let authorizationRequest = createAuthorizationRequest(responseMode: ResponseMode.directPostJwt.rawValue)
-        
-        XCTAssertThrowsError(try ClientMetadataSpecVersionHandler.of(.draft23).parseAndValidate(authorizationRequest: authorizationRequest, shouldValidateWithWalletMetadata: false, walletConfig: WalletConfig())) { error in
-            assertOpenID4VPException(error,
-                                     expectedMessage: "client_metadata must be present for given response mode",
-                                     expectedCode: OpenID4VPErrorCodes.invalidRequest
-            )
-        }
-    }
-    
     
     // Spec version v1 client metadata parsing tests
 
@@ -136,17 +124,6 @@ final class ClientMetadataUtilTests: XCTestCase {
         }
     }
 
-    func testV1ParsingOfClientMetadataThrowErrorWhenClientMetadataNotPresentAndResponseModeIsDirectPostJwt() throws {
-        let authorizationRequest = createAuthorizationRequest(responseMode: ResponseMode.directPostJwt.rawValue)
-
-        XCTAssertThrowsError(try ClientMetadataSpecVersionHandler.of(.v1).parseAndValidate(authorizationRequest: authorizationRequest, shouldValidateWithWalletMetadata: false, walletConfig: WalletConfig())) { error in
-            assertOpenID4VPException(
-                error,
-                expectedMessage: "client_metadata must be present for given response mode",
-                expectedCode: OpenID4VPErrorCodes.invalidRequest
-            )
-        }
-    }
     
     private func createAuthorizationRequest(clientMetadata: Any? = nil, responseMode: String = ResponseMode.directPost.rawValue) -> [String: Any] {
         if let clientMetadata = clientMetadata {

--- a/Tests/OpenID4VPTests/AuthorizationRequest/Utils/AuthorizationRequestUtilsTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationRequest/Utils/AuthorizationRequestUtilsTests.swift
@@ -58,14 +58,14 @@ class AuthorizationRequestUtilsTests : XCTestCase {
     ///Test get authorization request handler
     
     func testGetAuthorizationRequestHandlerToGiveRespectiveClientIdBasedAuthorizationRequestHandler(){
-        let mockSetResponseUri: (String) -> Void = { value in
+        let mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in
         }
-        let didAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: DidSchemeClientIdDraft23, walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
-        let preRegisteredSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: preRegisteredSchemeClientIdParameters,  walletConfig: walletConfig, setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+        let didAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: DidSchemeClientIdDraft23, walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
+        let preRegisteredSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: preRegisteredSchemeClientIdParameters,  walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce",networkManager: mockNetworkManager)
         let preRegisteredSchemeClientWithColonSeparatorAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters:  [
             "client_id": "https://mock-verifier.com",
-        ],  walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
-        let redirectUriSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: redirectUriSchemeClientIdParameter,  walletConfig: walletConfig, setResponseUri: mockSetResponseUri,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        ],  walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
+        let redirectUriSchemeAuthRequestHandler = try? getAuthorizationRequestHandler(authorizationRequestParameters: redirectUriSchemeClientIdParameter,  walletConfig: walletConfig, setResponseDispatchInfo: mockSetResponseDispatchInfo,walletNonce: "mock-nonce", networkManager: mockNetworkManager)
         
         
         XCTAssertTrue(didAuthRequestHandler is DecentralizedIdentifierPrefixAuthorizationRequestHandler)
@@ -86,8 +86,9 @@ class AuthorizationRequestUtilsTests : XCTestCase {
         
         for testCase in testCases {
             let authorizationRequestParametersWithInvalidClientId: [String : Any] = testCase.input as [String : Any]
+            let mockSetResponseDispatchInfo: (ResponseDispatchInfo) -> Void = { _ in }
             
-            XCTAssertThrowsError(try getAuthorizationRequestHandler(authorizationRequestParameters: authorizationRequestParametersWithInvalidClientId,  walletConfig: WalletConfig(validateTrustedVerifier: false), setResponseUri: mockSetResponseUri, walletNonce: "mock-nonce",networkManager: mockNetworkManager)){ error in
+            XCTAssertThrowsError(try getAuthorizationRequestHandler(authorizationRequestParameters: authorizationRequestParametersWithInvalidClientId,  walletConfig: WalletConfig(validateTrustedVerifier: false), setResponseDispatchInfo: mockSetResponseDispatchInfo, walletNonce: "mock-nonce",networkManager: mockNetworkManager)){ error in
                 assertOpenID4VPException(error,
                                          expectedMessage: testCase.expectedError!,
                                          expectedCode: OpenID4VPErrorCodes.invalidRequest

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -1,4 +1,5 @@
 @testable import OpenID4VP
+import JSONWebKey
 import XCTest
 
 final class AuthorizationResponseHandlerTests: XCTestCase {
@@ -8,6 +9,44 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
     let walletNonce = "_G6UkKgcsUPFlHAbzUMerA"
     let signatureSuite = SignatureSuite.ed25519Signature2020.rawValue
     let walletConfig = WalletConfig()
+
+    private func makeDispatchInfo(
+        responseMode: ResponseMode = .directPost,
+        responseUrl: String? = nil
+    ) -> ResponseDispatchInfo {
+        ResponseDispatchInfo(
+            responseMode: responseMode.rawValue,
+            nonce: "tHwahwI6M5_Cd_Sj5k2_Aw",
+            walletNonce: walletNonce,
+            state: "state",
+            clientId: "client_id",
+            responseUrl: responseUrl ?? responseUri,
+            responseEncryptionSpecification: nil
+        )
+    }
+
+    private func makeJwtDispatchInfo(responseUrl: String? = nil) throws -> ResponseDispatchInfo {
+        let encKeyJson: [String: Any] = [
+            "kty": "OKP", "crv": "X25519", "use": "enc",
+            "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+            "alg": "ECDH-ES", "kid": "ed-key1"
+        ]
+        let jwk = try JSONDecoder().decode(JWK.self, from: JSONSerialization.data(withJSONObject: encKeyJson))
+        let encSpec = ResponseEncryptionSpecification(
+            keyEncryptionAlg: EncryptionAlgorithm(rawValue: "ECDH-ES")!,
+            contentEncryptionAlg: EncryptionMethod(rawValue: "A256GCM")!,
+            verifierPublicKey: jwk
+        )
+        return ResponseDispatchInfo(
+            responseMode: ResponseMode.directPostJwt.rawValue,
+            nonce: "tHwahwI6M5_Cd_Sj5k2_Aw",
+            walletNonce: walletNonce,
+            state: "state",
+            clientId: "client_id",
+            responseUrl: responseUrl ?? responseUri,
+            responseEncryptionSpecification: encSpec
+        )
+    }
     
     // MARK: - OVP Spec Version Draft 23
     // MARK: Credential format = ldp_vc
@@ -48,7 +87,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let result = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults,
-            responseUri: responseUri
+            dispatchInfo: makeDispatchInfo()
         )
         
         XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
@@ -82,7 +121,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let result = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: mockAuthorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults,
-            responseUri: responseUri
+            dispatchInfo: try makeJwtDispatchInfo()
         )
         
         XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
@@ -100,7 +139,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             _ = try await handler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest: authorizationRequest,
                 vpTokenSigningResults: [],
-                responseUri: "https://client.example.org/cb"
+                dispatchInfo: makeDispatchInfo(responseUrl: "https://client.example.org/cb")
             )
             XCTFail("Expected error not thrown")
         } catch {
@@ -226,7 +265,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         _ = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: getMockAuthorizationRequest(specVersion: .draft23),
             vpTokenSigningResults: mockVPTokenSigningResults,
-            responseUri: responseUri
+            dispatchInfo: makeDispatchInfo()
         )
         
         // Extract actual response
@@ -295,7 +334,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let result = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: unsignedVPTokens.map { VPTokenSigningResult(id: $0.id, signedData: Data("ayuht".utf8)) },
-            responseUri: responseUri
+            dispatchInfo: makeDispatchInfo()
         )
         
         XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
@@ -324,7 +363,8 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
 
         let authorizationResponse = try handler.constructVPResponse(
             signingResults: [],
-            authorizationRequest: authorizationRequest
+            authorizationRequest: authorizationRequest,
+            dispatchInfo: nil
         )
 
         let encodedVpToken = try XCTUnwrap(authorizationResponse["vp_token"])
@@ -380,7 +420,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         _ = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults,
-            responseUri: responseUri
+            dispatchInfo: makeDispatchInfo()
         )
         
         let recordedRequest = (mockNetworkManager.recordedRequests[responseUri]!).requestBody
@@ -415,7 +455,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             _ = try await handler.constructAndSendAuthorizationResponseToVerifier(
                 authorizationRequest: authorizationRequest,
                 vpTokenSigningResults: vpTokenSigningResults,
-                responseUri: "https://client.example.org/cb"
+                dispatchInfo: makeDispatchInfo(responseUrl: "https://client.example.org/cb")
             )
             XCTFail("Expected error not thrown")
         } catch {
@@ -473,7 +513,8 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         }
         
         let authorizationResponse = try handler.constructVPResponse(
-            signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest
+            signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest,
+            dispatchInfo: nil
         )
         
         XCTAssertNotNil(authorizationResponse["vp_token"])
@@ -488,7 +529,8 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         XCTAssertThrowsError(
             try handler.constructVPResponse(
                 signingResults: [],
-                authorizationRequest: authorizationRequest
+                authorizationRequest: authorizationRequest,
+                dispatchInfo: nil
             )
         ) { error in
             assertOpenID4VPException(error,
@@ -580,7 +622,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let result = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults,
-            responseUri: responseUri
+            dispatchInfo: makeDispatchInfo()
         )
 
         XCTAssertEqual(result.body(), "sending is success in AuthorizationResponseTests")
@@ -592,13 +634,12 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
 
     func testV1ConstructAndSendAuthorizationResponseThrowsForUnsupportedResponseType() async {
         let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
-        // spec version v1, unsupported response type
         let authorizationRequest = getMockAuthorizationRequest(responseType: "fragment", specVersion: .v1)
-        
+
         await XCTAssertAsyncThrowsError(try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: [],
-            responseUri: "https://client.example.org/cb"
+            dispatchInfo: makeDispatchInfo(responseUrl: "https://client.example.org/cb")
         )) { error in
             assertOpenID4VPException(
                 error,
@@ -675,7 +716,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         _ = try await handler.constructAndSendAuthorizationResponseToVerifier(
             authorizationRequest: authorizationRequest,
             vpTokenSigningResults: vpTokenSigningResults,
-            responseUri: responseUri
+            dispatchInfo: makeDispatchInfo()
         )
 
         let recordedRequest = mockNetworkManager.recordedRequests[responseUri]!.requestBody
@@ -704,7 +745,8 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         }
 
         let authorizationResponse = try handler.constructVPResponse(
-            signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest
+            signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest,
+            dispatchInfo: nil
         )
 
         XCTAssertNotNil(authorizationResponse["vp_token"])
@@ -716,7 +758,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let authorizationRequest = getMockAuthorizationRequest(responseType: "fragment", specVersion: .v1)
 
         XCTAssertThrowsError(try handler.constructVPResponse(
-            signingResults: [], authorizationRequest: authorizationRequest
+            signingResults: [], authorizationRequest: authorizationRequest, dispatchInfo: nil
         )) { error in
             assertOpenID4VPException(error,
                                      expectedMessage: "The wallet encountered an internal error while preparing the authorization response.",

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -364,7 +364,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let authorizationResponse = try handler.constructVPResponse(
             signingResults: [],
             authorizationRequest: authorizationRequest,
-            dispatchInfo: nil
+            dispatchInfo: makeDispatchInfo()
         )
 
         let encodedVpToken = try XCTUnwrap(authorizationResponse["vp_token"])
@@ -514,7 +514,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         
         let authorizationResponse = try handler.constructVPResponse(
             signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest,
-            dispatchInfo: nil
+            dispatchInfo: makeDispatchInfo()
         )
         
         XCTAssertNotNil(authorizationResponse["vp_token"])
@@ -746,7 +746,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
 
         let authorizationResponse = try handler.constructVPResponse(
             signingResults: vpTokenSigningResults, authorizationRequest: authorizationRequest,
-            dispatchInfo: nil
+            dispatchInfo: makeDispatchInfo()
         )
 
         XCTAssertNotNil(authorizationResponse["vp_token"])
@@ -809,7 +809,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let dispatchInfo = ResponseDispatchInfo(
             responseMode: ResponseMode.directPost.rawValue,
             nonce: "nonce",
-            walletNonce: nil,
+            walletNonce: "wallet-nonce",
             state: state,
             clientId: "mock-client",
             responseUrl: responseUri,

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -553,8 +553,9 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         ) { error in
             assertOpenID4VPException(
                 error,
-                expectedMessage: "Failed to send error to verifier: Response dispatch details are not set. Cannot send authorization response to verifier.",
-                expectedCode: OpenID4VPErrorCodes.errorDispatchFailure
+                expectedMessage: "The wallet encountered an internal error while preparing the authorization response.",
+                expectedCode: OpenID4VPErrorCodes.serverError,
+                expectedUnderlyingErrorMessage: "Failed to send error to verifier: Response dispatch details are not set. Cannot send authorization response to verifier."
             )
         }
     }

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -759,4 +759,60 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         XCTAssertNotNil(response["error_description"])
         XCTAssertEqual(response["state"] as? String, state)
     }
+
+    func testSendAuthorizationErrorWithDispatchInfoSendsErrorViaResponseModeHandler() async throws {
+        let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
+        let authorizationRequest = getMockAuthorizationRequest(responseMode: .directPost, specVersion: .draft23)
+        let error = AccessDenied(message: "User denied", className: "test")
+        let dispatchInfo = ResponseDispatchInfo(
+            responseMode: ResponseMode.directPost.rawValue,
+            nonce: "nonce",
+            walletNonce: nil,
+            state: state,
+            clientId: "mock-client",
+            responseUrl: responseUri,
+            responseEncryptionSpecification: nil
+        )
+
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "{\"message\":\"Some additional info\"}")
+
+        let verifierResponse = try await handler.sendAuthorizationError(
+            dispatchInfo: dispatchInfo,
+            authorizationRequest: authorizationRequest,
+            error: error
+        )
+
+        XCTAssertEqual(verifierResponse.statusCode, 200)
+        let recordedRequest = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertNotNil(recordedRequest)
+        XCTAssertEqual(recordedRequest?.requestBody?["error"] as? String, "access_denied")
+        XCTAssertEqual(recordedRequest?.requestBody?["error_description"] as? String, "User denied")
+        XCTAssertEqual(recordedRequest?.requestBody?["state"] as? String, state)
+    }
+
+    func testSendAuthorizationErrorWithDispatchInfoThrowsWhenNetworkFails() async throws {
+        let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
+        let error = AccessDenied(message: "Denied", className: "test")
+        let failingUrl = "https://failing-verifier.com"
+        let dispatchInfo = ResponseDispatchInfo(
+            responseMode: ResponseMode.directPost.rawValue,
+            nonce: nil,
+            walletNonce: nil,
+            state: nil,
+            clientId: "mock-client",
+            responseUrl: failingUrl,
+            responseEncryptionSpecification: nil
+        )
+        mockNetworkManager.setMockResponse(for: failingUrl, error: NSError(domain: "NetworkError", code: -1))
+
+        await XCTAssertAsyncThrowsError(
+            try await handler.sendAuthorizationError(
+                dispatchInfo: dispatchInfo,
+                authorizationRequest: nil,
+                error: error
+            )
+        ) { thrownError in
+            XCTAssertTrue(thrownError.localizedDescription.contains("Failed to send error to verifier"))
+        }
+    }
 }

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -25,28 +25,7 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         )
     }
 
-    private func makeJwtDispatchInfo(responseUrl: String? = nil) throws -> ResponseDispatchInfo {
-        let encKeyJson: [String: Any] = [
-            "kty": "OKP", "crv": "X25519", "use": "enc",
-            "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-            "alg": "ECDH-ES", "kid": "ed-key1"
-        ]
-        let jwk = try JSONDecoder().decode(JWK.self, from: JSONSerialization.data(withJSONObject: encKeyJson))
-        let encSpec = ResponseEncryptionSpecification(
-            keyEncryptionAlg: EncryptionAlgorithm(rawValue: "ECDH-ES")!,
-            contentEncryptionAlg: EncryptionMethod(rawValue: "A256GCM")!,
-            verifierPublicKey: jwk
-        )
-        return ResponseDispatchInfo(
-            responseMode: ResponseMode.directPostJwt.rawValue,
-            nonce: "tHwahwI6M5_Cd_Sj5k2_Aw",
-            walletNonce: walletNonce,
-            state: "state",
-            clientId: "client_id",
-            responseUrl: responseUrl ?? responseUri,
-            responseEncryptionSpecification: encSpec
-        )
-    }
+    // makeJwtDispatchInfo is provided by the shared makeJwtDispatchInfo() free function in TestUtils.swift
     
     // MARK: - OVP Spec Version Draft 23
     // MARK: Credential format = ldp_vc
@@ -540,6 +519,45 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
             )
         }
     }
+
+    func testConstructVPResponseThrowsErrorDispatchFailureWhenDispatchInfoIsNil() {
+        let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
+        let authorizationRequest = getMockAuthorizationRequest(specVersion: .draft23)
+
+        XCTAssertThrowsError(
+            try handler.constructVPResponse(
+                signingResults: [],
+                authorizationRequest: authorizationRequest,
+                dispatchInfo: nil
+            )
+        ) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "The wallet encountered an internal error while preparing the authorization response.",
+                expectedCode: OpenID4VPErrorCodes.serverError,
+                expectedUnderlyingErrorMessage: "Failed to send error to verifier: Response dispatch details are not set. Cannot construct VP response."
+            )
+        }
+    }
+
+    func testConstructAndSendThrowsErrorDispatchFailureWhenDispatchInfoIsNil() async {
+        let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
+        let authorizationRequest = getMockAuthorizationRequest(specVersion: .draft23)
+
+        await XCTAssertAsyncThrowsError(
+            try await handler.constructAndSendAuthorizationResponseToVerifier(
+                authorizationRequest: authorizationRequest,
+                vpTokenSigningResults: [],
+                dispatchInfo: nil
+            )
+        ) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Failed to send error to verifier: Response dispatch details are not set. Cannot send authorization response to verifier.",
+                expectedCode: OpenID4VPErrorCodes.errorDispatchFailure
+            )
+        }
+    }
     
     func testConstructAuthorizationErrorResponseWithOpenIDException() {
         let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
@@ -842,6 +860,29 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         XCTAssertEqual(recordedRequest?.requestBody?["error"] as? String, "access_denied")
         XCTAssertEqual(recordedRequest?.requestBody?["error_description"] as? String, "User denied")
         XCTAssertEqual(recordedRequest?.requestBody?["state"] as? String, state)
+    }
+
+    func testSendAuthorizationErrorWithJwtDispatchInfoSendsEncryptedResponse() async throws {
+        let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
+        let authorizationRequest = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23)
+        let error = AccessDenied(message: "User denied", className: "test")
+        let dispatchInfo = try makeJwtDispatchInfo(responseUrl: responseUri)
+
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "{\"message\":\"Some additional info\"}")
+
+        let verifierResponse = try await handler.sendAuthorizationError(
+            dispatchInfo: dispatchInfo,
+            authorizationRequest: authorizationRequest,
+            error: error
+        )
+
+        XCTAssertEqual(verifierResponse.statusCode, 200)
+        let recordedRequest = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertNotNil(recordedRequest)
+        XCTAssertNotNil(recordedRequest?.requestBody?["response"], "Error should be encrypted for direct_post.jwt")
+        XCTAssertNil(recordedRequest?.requestBody?["error"])
+        XCTAssertNil(recordedRequest?.requestBody?["error_description"])
+        XCTAssertNil(recordedRequest?.requestBody?["state"])
     }
 
     func testSendAuthorizationErrorWithDispatchInfoThrowsWhenNetworkFails() async throws {

--- a/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
+++ b/Tests/OpenID4VPTests/AuthorizationResponse/AuthorizationResponseHandlerTests.swift
@@ -480,14 +480,14 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
         let authorizationRequest = getMockAuthorizationRequest(specVersion: .draft23)
         let error = InvalidData(message: "Invalid input data", className: "Test")
-        
-        
+
         let response = handler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: error,
-            walletNonce: "wallet-nonce"
+            dispatchInfo: makeDispatchInfo(),
+            error: error,
+            walletNonce: "wallet-nonce",
+            authorizationRequest: authorizationRequest
         )
-        
+
         XCTAssertEqual(response["error"] as? String, "invalid_request")
         XCTAssertEqual(response["error_description"] as? String, "Invalid input data")
         XCTAssertEqual(response["state"] as? String, state)
@@ -544,53 +544,63 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
     func testConstructAuthorizationErrorResponseWithOpenIDException() {
         let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
         let authorizationRequest = getMockAuthorizationRequest(specVersion: .draft23)
-        
+
         let error = InvalidData(
             message: "Invalid input data",
             className: "TestClass"
         )
-        
+
         let response = handler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: error,
-            walletNonce: "wallet-nonce"
+            dispatchInfo: makeDispatchInfo(),
+            error: error,
+            walletNonce: "wallet-nonce",
+            authorizationRequest: authorizationRequest
         )
-        
+
         XCTAssertEqual(response["error"] as? String, "invalid_request")
         XCTAssertEqual(response["error_description"] as? String, "Invalid input data")
         XCTAssertEqual(response["state"] as? String, state)
     }
-    
+
     func testConstructAuthorizationErrorResponseWithGenericError() {
         let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
         let authorizationRequest = getMockAuthorizationRequest(specVersion: .draft23)
-        
+
         let error = NSError(domain: "test", code: 500)
-        
+
         let response = handler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: error,
-            walletNonce: "wallet-nonce"
+            dispatchInfo: makeDispatchInfo(),
+            error: error,
+            walletNonce: "wallet-nonce",
+            authorizationRequest: authorizationRequest
         )
-        
+
         XCTAssertEqual(response["error"] as? String, "server_error")
         XCTAssertNotNil(response["error_description"])
         XCTAssertEqual(response["state"] as? String, state)
     }
-    
+
     // common spec version agnostic tests
     func testConstructAuthorizationErrorResponseReturnMinimalErrorResponseIfConstructionOfErrorFails() {
         let handler = AuthorizationResponseHandler(networkManager: mockNetworkManager, walletConfig: walletConfig)
-        let authorizationRequest = getMockAuthorizationRequest(responseModeValue: "fragment" )
-        
+        let dispatchInfo = ResponseDispatchInfo(
+            responseMode: "fragment",
+            nonce: nil,
+            walletNonce: nil,
+            state: nil,
+            clientId: "mock-client",
+            responseUrl: responseUri,
+            responseEncryptionSpecification: nil
+        )
+
         let error = NSError(domain: "test", code: 500)
-        
+
         let response = handler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: error,
+            dispatchInfo: dispatchInfo,
+            error: error,
             walletNonce: "wallet-nonce"
         )
-        
+
         XCTAssertEqual(response["error"] as? String, "invalid_request")
         XCTAssertNotNil(response["error_description"])
         XCTAssertTrue((response["error_description"] as? String)?.starts(with: "Failed to construct error response:") == true)
@@ -776,9 +786,10 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let error = InvalidData(message: "Invalid input data", className: "Test")
 
         let response = handler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: error,
-            walletNonce: "wallet-nonce"
+            dispatchInfo: makeDispatchInfo(),
+            error: error,
+            walletNonce: "wallet-nonce",
+            authorizationRequest: authorizationRequest
         )
 
         XCTAssertEqual(response["error"] as? String, "invalid_request")
@@ -792,9 +803,10 @@ final class AuthorizationResponseHandlerTests: XCTestCase {
         let error = NSError(domain: "test", code: 500)
 
         let response = handler.constructAuthorizationErrorResponse(
-            authorizationRequest: authorizationRequest,
-            exception: error,
-            walletNonce: "wallet-nonce"
+            dispatchInfo: makeDispatchInfo(),
+            error: error,
+            walletNonce: "wallet-nonce",
+            authorizationRequest: authorizationRequest
         )
 
         XCTAssertEqual(response["error"] as? String, "server_error")

--- a/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
+++ b/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
@@ -13,7 +13,7 @@ final class MockAuthorizationResponseHandler: AuthorizationResponseHandler {
     var expectedErrorResponse: [String: String] = [:]
     var expectedUnsignedVPTokens: [UnsignedVPToken] = []
     var expectedVPResponse: [String: String] = [:]
-
+    
     override func constructAuthorizationErrorResponse(
         authorizationRequest: AuthorizationRequest?,
         exception: Error,
@@ -29,7 +29,7 @@ final class MockAuthorizationResponseHandler: AuthorizationResponseHandler {
     ) async throws -> [UnsignedVPToken] {
         return expectedUnsignedVPTokens
     }
-
+    
     override func constructVPResponse(
         signingResults: [VPTokenSigningResult],
         authorizationRequest: AuthorizationRequest
@@ -44,14 +44,18 @@ final class MockAuthorizationResponseHandler: AuthorizationResponseHandler {
 class MockResponseModeHandler: ResponseModeBasedHandler {
     var expectedSuccessResponse: [String: String] = [:]
     var expectedErrorResponse: [String: String] = [:]
-
+    
     func validate(clientMetadata: ClientMetadataDraft23?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws {}
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
+        return nil
+    }
     
     func validate(clientMetadata: ClientMetadata?,
                   walletConfig: WalletConfig,
-                  shouldValidateWithWalletMetadata: Bool) throws {}
+                  shouldValidateWithWalletMetadata: Bool) throws -> ResponseEncryptionSpecification? {
+        return nil
+    }
     
     func sendAuthorizationResponse(
         authorizationRequest: AuthorizationRequest,
@@ -64,8 +68,10 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     ) async throws -> NetworkResponse {
         fatalError("Not needed for unit testing constructAuthorizationResponse")
     }
-
-    func setResponseUrl(authorizationRequestParameters: [String : Any], setResponseUri: (String) -> Void) throws {}
+    
+    func setResponseUrl(authorizationRequestParameters: [String : Any]) throws -> String {
+        return authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String ?? "https://example.com/callback"
+    }
     
     func getAuthorizationResponse(
         authorizationRequest: AuthorizationRequest,
@@ -75,18 +81,18 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     ) throws -> [String: String] {
         return expectedSuccessResponse
     }
-
+    
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
-                walletConfig: WalletConfig
+        walletConfig: WalletConfig
     ) throws -> JWK? {
         return nil
     }
     
-    func getResponseEndpoint(authorizationRequest: AuthorizationRequest) throws -> String {
-        return authorizationRequest.responseUri ?? "https://example.com/callback"
+    func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String {
+        return authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String ?? "https://example.com/callback"
     }
-
+    
     func getAuthorizationErrorResponse(
         authorizationRequest: AuthorizationRequest?,
         authorizationResponse: AuthorizationErrorResponse,
@@ -94,14 +100,14 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     ) throws -> [String: String] {
         return expectedErrorResponse
     }
-
+    
     func getAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse
     ) throws -> [String: String] {
         return expectedErrorResponse
     }
-
+    
     func sendAuthorizationError(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
@@ -109,14 +115,14 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     ) async throws -> NetworkResponse {
         fatalError("Not needed for unit testing")
     }
-
+    
     func getAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse
     ) throws -> [String: String] {
         return expectedSuccessResponse
     }
-
+    
     func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,

--- a/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
+++ b/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
@@ -104,7 +104,8 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     
     func getAuthorizationErrorResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationErrorResponse
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
     ) throws -> [String: String] {
         return expectedErrorResponse
     }
@@ -112,6 +113,7 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     func sendAuthorizationError(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse {
         fatalError("Not needed for unit testing")
@@ -119,7 +121,8 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     
     func getAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
-        authorizationResponse: AuthorizationResponse
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
     ) throws -> [String: String] {
         return expectedSuccessResponse
     }
@@ -127,6 +130,7 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     func sendAuthorizationResponse(
         dispatchInfo: ResponseDispatchInfo,
         authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest,
         networkManager: NetworkManaging
     ) async throws -> NetworkResponse {
         fatalError("Not needed for unit testing")

--- a/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
+++ b/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
@@ -15,9 +15,10 @@ final class MockAuthorizationResponseHandler: AuthorizationResponseHandler {
     var expectedVPResponse: [String: String] = [:]
     
     override func constructAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        exception: Error,
-        walletNonce: String
+        dispatchInfo: ResponseDispatchInfo?,
+        error: Error,
+        walletNonce: String,
+        authorizationRequest: AuthorizationRequest?
     ) -> [String: Any] {
         return expectedErrorResponse
     }
@@ -58,31 +59,6 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
         return nil
     }
     
-    func sendAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        url: String,
-        networkManager: any NetworkManaging,
-        producerInfo: String,
-        recipientInfo: String,
-        walletConfig: WalletConfig
-    ) async throws -> NetworkResponse {
-        fatalError("Not needed for unit testing constructAuthorizationResponse")
-    }
-    
-    func setResponseUrl(authorizationRequestParameters: [String : Any]) throws -> String {
-        return authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String ?? "https://example.com/callback"
-    }
-    
-    func getAuthorizationResponse(
-        authorizationRequest: AuthorizationRequest,
-        authorizationResponse: AuthorizationResponse,
-        walletNonce: String,
-        walletConfig: WalletConfig
-    ) throws -> [String: String] {
-        return expectedSuccessResponse
-    }
-    
     func getVerifierPublicKeyForEncryption(
         authorizationRequest: AuthorizationRequest,
         walletConfig: WalletConfig
@@ -92,14 +68,6 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     
     func getResponseEndpoint(authorizationRequestParameters: [String : Any]) throws -> String {
         return authorizationRequestParameters[AuthorizationRequestFieldConstants.responseUri] as? String ?? "https://example.com/callback"
-    }
-    
-    func getAuthorizationErrorResponse(
-        authorizationRequest: AuthorizationRequest?,
-        authorizationResponse: AuthorizationErrorResponse,
-        walletNonce: String
-    ) throws -> [String: String] {
-        return expectedErrorResponse
     }
     
     func getAuthorizationErrorResponse(

--- a/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
+++ b/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
@@ -32,7 +32,8 @@ final class MockAuthorizationResponseHandler: AuthorizationResponseHandler {
     
     override func constructVPResponse(
         signingResults: [VPTokenSigningResult],
-        authorizationRequest: AuthorizationRequest
+        authorizationRequest: AuthorizationRequest,
+        dispatchInfo: ResponseDispatchInfo?
     ) throws -> [String: String] {
         if(!expectedErrorResponse.isEmpty) {
             return expectedErrorResponse

--- a/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
+++ b/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
@@ -94,4 +94,34 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
     ) throws -> [String: String] {
         return expectedErrorResponse
     }
+
+    func getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse
+    ) throws -> [String: String] {
+        return expectedErrorResponse
+    }
+
+    func sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        fatalError("Not needed for unit testing")
+    }
+
+    func getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse
+    ) throws -> [String: String] {
+        return expectedSuccessResponse
+    }
+
+    func sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        fatalError("Not needed for unit testing")
+    }
 }

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -409,7 +409,7 @@ class OpenID4VPTests: XCTestCase {
 
         // directly call sendErrorInfoToVerifier
         await XCTAssertAsyncThrowsError(try await openID4VP.sendErrorInfoToVerifier(error: error)) { error in
-            XCTAssertEqual(error.localizedDescription, "Failed to send error to verifier: Response URI is not set. Cannot send error to verifier.", "error_dispatch_failure")
+            XCTAssertEqual(error.localizedDescription, "Failed to send error to verifier: Response dispatch details are not set. Cannot send error to verifier.")
         }
     }
 

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -447,6 +447,76 @@ class OpenID4VPTests: XCTestCase {
         }
     }
 
+    func testAuthenticateVerifierDirectPostJwtSendsEncryptedErrorWhenValidationFailsAfterDispatchInfoPopulation() async {
+        let draft23JwtClientMetadata = clientMetadataSpecVersionDraft23.merging([
+            "authorization_encrypted_response_alg": "ECDH-ES",
+            "authorization_encrypted_response_enc": "A256GCM"
+        ]) { _, new in new }
+        let invalidPresentationDefinitionRequest = createUrlEncodedAuthorizationRequest(
+            requestParams: mergeMaps(
+                authorizationRequestParamsWithValue,
+                preRegisteredSchemeClientIdParameters,
+                [
+                    AuthorizationRequestFieldConstants.responseMode: ResponseMode.directPostJwt.rawValue,
+                    AuthorizationRequestFieldConstants.presentationDefinition: convertToJsonString(["input_descriptor": []]),
+                    AuthorizationRequestFieldConstants.clientMetadata: draft23JwtClientMetadata
+                ]
+            ),
+            clientIdPrefix: .preRegistered,
+            specVersion: .draft23
+        )
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "{\"message\":\"Some additional info\"}")
+
+        await XCTAssertAsyncThrowsError(
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: invalidPresentationDefinitionRequest)
+        ) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Missing Input: presentation_definition->id param is required",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+
+        let recordedRequest = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertNotNil(recordedRequest)
+        XCTAssertNotNil(recordedRequest?.requestBody?["response"])
+        XCTAssertNil(recordedRequest?.requestBody?["error"])
+        XCTAssertNil(recordedRequest?.requestBody?["error_description"])
+    }
+
+    func testAuthenticateVerifierDirectPostJwtSendsEncryptedErrorWhenValidationFailsAfterDispatchInfoPopulationSpecV1() async {
+        let invalidDcqlQueryRequest = createUrlEncodedAuthorizationRequest(
+            requestParams: mergeMaps(
+                authorizationRequestParamsWithValue,
+                preRegisteredSchemeClientIdParameters,
+                [
+                    AuthorizationRequestFieldConstants.responseMode: ResponseMode.directPostJwt.rawValue,
+                    AuthorizationRequestFieldConstants.dcqlQuery: convertToJsonString(["credentials": []]),
+                    AuthorizationRequestFieldConstants.clientMetadata: clientMetadataSpecVersion1
+                ]
+            ),
+            clientIdPrefix: .preRegistered,
+            specVersion: .v1
+        )
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "{\"message\":\"Some additional info\"}")
+
+        await XCTAssertAsyncThrowsError(
+            try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: invalidDcqlQueryRequest)
+        ) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Invalid Input: dcql_query->credentials value cannot be empty or null",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+
+        let recordedRequest = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertNotNil(recordedRequest)
+        XCTAssertNotNil(recordedRequest?.requestBody?["response"])
+        XCTAssertNil(recordedRequest?.requestBody?["error"])
+        XCTAssertNil(recordedRequest?.requestBody?["error_description"])
+    }
+
     func testAuthenticateVerifierSuccess_WithRedirectUriClientIdPrefix() async {
         let authorizationRequest = baseAuthRequest(
             clientId: "redirect_uri:https://example.com/iar/callback",
@@ -572,6 +642,4 @@ class OpenID4VPTests: XCTestCase {
 //        }
 //    }
 }
-
-
 

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -22,7 +22,7 @@ class OpenID4VPTests: XCTestCase {
         "{\"name\":\"dummyClient\"}"
     let processedSuccessfullyMessage = "{\"message\":\"Some additional info\"}"
     let responseUri = "https://mock-verifier.com"
-    let responseDispatchInfo = ResponseDispatchInfo(responseMode: "direct_post", nonce: "vakue", walletNonce: "wallet-nonce", state: "state", clientId: "clientId", responseUrl: "mock-verifier.com")
+    let responseDispatchInfo = ResponseDispatchInfo(responseMode: "direct_post", nonce: "vakue", walletNonce: "wallet-nonce", state: "state", clientId: "clientId", responseUrl: "https://mock-verifier.com")
     var walletConfig : WalletConfig!
 
     override func setUp() {

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -22,6 +22,7 @@ class OpenID4VPTests: XCTestCase {
         "{\"name\":\"dummyClient\"}"
     let processedSuccessfullyMessage = "{\"message\":\"Some additional info\"}"
     let responseUri = "https://mock-verifier.com"
+    let responseDispatchInfo = ResponseDispatchInfo(responseMode: "direct_post", nonce: "vakue", walletNonce: "wallet-nonce", state: "state", clientId: "clientId", responseUrl: "mock-verifier.com")
     var walletConfig : WalletConfig!
 
     override func setUp() {
@@ -36,7 +37,7 @@ class OpenID4VPTests: XCTestCase {
             nonceProvider: MockNonceProvider(),
             jsonLdCanonicalizer: { _ in "Y2Fub25pY2FsaXplZA" }
         )
-        openID4VP.setResponseUri("https://mock-verifier.com")
+        openID4VP.setResponseDispatchInfo(ResponseDispatchInfo(responseMode: "direct_post", nonce: nil, walletNonce: nil, state: nil, clientId: "", responseUrl: "https://mock-verifier.com", responseEncryptionSpecification: nil))
         openID4VP.authorizationRequest = authorizationRequest
         
         JsonLd.setCanonicalizer { _ in "Y2Fub25pY2FsaXplZA" }
@@ -368,9 +369,9 @@ class OpenID4VPTests: XCTestCase {
         // first call
         _ = try await openID4VP.authenticateVerifier(urlEncodedAuthorizationRequest: testValidSignedVPRequestWithDid)
         let firstMirror = Mirror(reflecting: openID4VP as Any)
-        let firstResponseUri = firstMirror.children.first(where: { $0.label == "responseUri" })?.value as? String
+        let firstResponseDispatchInfo = firstMirror.children.first(where: { $0.label == "responseDispatchInfo" })?.value
         let firstAuthorizationRequest = firstMirror.children.first(where: { $0.label == "authorizationRequest" })?.value as? AuthorizationRequest
-        XCTAssertNotNil(firstResponseUri, "responseUri should not be nil after first authenticateVerifier call")
+        XCTAssertNotNil(firstResponseDispatchInfo, "responseDispatchInfo should not be nil after first authenticateVerifier call")
         XCTAssertNotNil(firstAuthorizationRequest, "authorizedRequest should not be nil after first authenticateVerifier call")
 
         // second call
@@ -393,12 +394,12 @@ class OpenID4VPTests: XCTestCase {
             )
         }
         let secondMirror = Mirror(reflecting: openID4VP as Any)
-        let secondResponseUri = secondMirror.children.first(where: { $0.label == "responseUri" })?.value as? String
+        let secondResponseDispatchInfo = secondMirror.children.first(where: { $0.label == "responseDispatchInfo" })?.value
         let secondAuthorizationRequest = secondMirror.children.first(where: { $0.label == "authorizationRequest" })?.value as? AuthorizationRequest
-        XCTAssertNil(secondResponseUri, "responseUri should be nil after second authenticateVerifier call which throws error")
+        XCTAssertNil(secondResponseDispatchInfo as? ResponseDispatchInfo, "responseDispatchInfo should be nil after second authenticateVerifier call which throws error")
         XCTAssertNil(secondAuthorizationRequest, "authorizedRequest should be nil after second authenticateVerifier call which throws error")
-        // No error to verifier to be sent as no response uri is available
-        XCTAssertTrue(mockNetworkManager.recordedRequests.count == 2, "No requests should be recorded as responseUri is nil")
+        // No error to verifier to be sent as no response dispatch info is available
+        XCTAssertTrue(mockNetworkManager.recordedRequests.count == 2, "No requests should be recorded as responseDispatchInfo is nil")
     }
 
     func testThrowErrorWhenResponseUriNotAvailableDuringsendErrorInfoToVerifier
@@ -418,7 +419,7 @@ class OpenID4VPTests: XCTestCase {
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: processedSuccessfullyMessage)
 
         let openID4VP = OpenID4VP(traceabilityId: "trace-id", networkManager: mockNetworkManager)
-        openID4VP.setResponseUri(responseUri)
+        openID4VP.setResponseDispatchInfo(ResponseDispatchInfo(responseMode: "direct_post", nonce: nil, walletNonce: nil, state: nil, clientId: "", responseUrl: responseUri, responseEncryptionSpecification: nil))
 
         await XCTAssertNoThrowAndVerifyAsync(try await openID4VP.sendErrorInfoToVerifier(error: error)) { result in
             XCTAssertEqual(result.body(), "{\"message\":\"Some additional info\"}")
@@ -522,7 +523,7 @@ class OpenID4VPTests: XCTestCase {
 
         let openIdVP = OpenID4VP(traceabilityId: "AXESWSAW123", networkManager: mockNetworkManager, nonceProvider: MockNonceProvider(), authorizationResponseHandler: handler)
         openIdVP.authorizationRequest = mockAuthorizationRequestObjectWithDirectPostJwtResponseMode
-        openIdVP.setResponseUri(responseUri)
+        openIdVP.setResponseDispatchInfo(responseDispatchInfo)
 
         do {
             let result = try await openIdVP.constructUnsignedVPToken(
@@ -544,7 +545,7 @@ class OpenID4VPTests: XCTestCase {
         openIdVP.authorizationRequest = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23)
 
         mockNetworkManager.setMockResponse(for: responseUri, responseBody: processedSuccessfullyMessage)
-        openIdVP.setResponseUri(responseUri)
+        openIdVP.setResponseDispatchInfo(responseDispatchInfo)
 
         // Credential with no credentialSubject — extraction of holderId will fail
         let credentialWithNoSubject: [String: Any] = ["type": ["VerifiableCredential"]]

--- a/Tests/OpenID4VPTests/OpenID4VPTests.swift
+++ b/Tests/OpenID4VPTests/OpenID4VPTests.swift
@@ -564,13 +564,13 @@ class OpenID4VPTests: XCTestCase {
         }
     }
     
-    func testSendVPResponseToVerifierThrowsErrorWhenResponseUriIsNotPopulated() async {
-        let openIdVP = OpenID4VP(traceabilityId: "AXESWSAW123", networkManager: mockNetworkManager, nonceProvider: MockNonceProvider())
-        
-        await XCTAssertAsyncThrowsError(try await openIdVP.sendVPResponseToVerifier(vpTokenSigningResults: [VPTokenSigningResult(id: "uuid1", signedData: "signed".data(using: .utf8) ?? Data())])) { error in
-            XCTAssertEqual(error.localizedDescription, "Response URI is not available to send any response to Verifier", "error_dispatch_failure")
-        }
-    }
+//    func testSendVPResponseToVerifierThrowsErrorWhenResponseUriIsNotPopulated() async {
+//        let openIdVP = OpenID4VP(traceabilityId: "AXESWSAW123", networkManager: mockNetworkManager, nonceProvider: MockNonceProvider())
+//        
+//        await XCTAssertAsyncThrowsError(try await openIdVP.sendVPResponseToVerifier(vpTokenSigningResults: [VPTokenSigningResult(id: "uuid1", signedData: "signed".data(using: .utf8) ?? Data())])) { error in
+//            XCTAssertEqual(error.localizedDescription, "Response URI is not available to send any response to Verifier", "error_dispatch_failure")
+//        }
+//    }
 }
 
 

--- a/Tests/OpenID4VPTests/ResponseModeHandler/ResponseModeBasedHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/ResponseModeBasedHandlerTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+import JSONWebKey
+@testable import OpenID4VP
+
+private final class ExtensionOnlyResponseModeHandler: ResponseModeBasedHandler {
+    func validate(
+        clientMetadata: ClientMetadata?,
+        walletConfig: WalletConfig,
+        shouldValidateWithWalletMetadata: Bool
+    ) throws -> ResponseEncryptionSpecification? {
+        nil
+    }
+
+    func validate(
+        clientMetadata: ClientMetadataDraft23?,
+        walletConfig: WalletConfig,
+        shouldValidateWithWalletMetadata: Bool
+    ) throws -> ResponseEncryptionSpecification? {
+        nil
+    }
+
+    func getVerifierPublicKeyForEncryption(
+        authorizationRequest: AuthorizationRequest,
+        walletConfig: WalletConfig
+    ) throws -> JWK? {
+        nil
+    }
+
+    func getAuthorizationErrorResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?
+    ) throws -> [String: String] {
+        [:]
+    }
+
+    func sendAuthorizationError(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationErrorResponse,
+        authorizationRequest: AuthorizationRequest?,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        fatalError("Not needed for this test suite")
+    }
+
+    func getAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest
+    ) throws -> [String: String] {
+        [:]
+    }
+
+    func sendAuthorizationResponse(
+        dispatchInfo: ResponseDispatchInfo,
+        authorizationResponse: AuthorizationResponse,
+        authorizationRequest: AuthorizationRequest,
+        networkManager: NetworkManaging
+    ) async throws -> NetworkResponse {
+        fatalError("Not needed for this test suite")
+    }
+}
+
+final class ResponseModeBasedHandlerTests: XCTestCase {
+    private let handler = ExtensionOnlyResponseModeHandler()
+
+    func testGetResponseEndpointFromMapReturnsResponseUriWhenValid() throws {
+        let endpoint = try handler.getResponseEndpoint(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com/callback"
+        ])
+
+        XCTAssertEqual(endpoint, "https://mock-verifier.com/callback")
+    }
+
+    func testGetResponseEndpointFromMapThrowsWhenResponseUriMissing() {
+        XCTAssertThrowsError(try handler.getResponseEndpoint(authorizationRequestParameters: [:])) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Missing Input: response_uri param is required",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testGetResponseEndpointFromMapThrowsWhenResponseUriIsNotValid() {
+        XCTAssertThrowsError(try handler.getResponseEndpoint(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: 12345
+        ])) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "response_uri data is not valid",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testGetResponseEndpointFromAuthorizationRequestReturnsResponseUri() throws {
+        let authorizationRequest = getMockAuthorizationRequest()
+
+        let endpoint = try handler.getResponseEndpoint(authorizationRequest: authorizationRequest)
+
+        XCTAssertEqual(endpoint, "https://mock-verifier.com")
+    }
+
+    func testGetResponseEndpointFromAuthorizationRequestReturnsEmptyWhenMissing() throws {
+        let authorizationRequest = AuthorizationDcqlRequest(
+            clientId: "mock-client",
+            responseType: ResponseType.vp_token.rawValue,
+            responseMode: ResponseMode.directPost.rawValue,
+            responseUri: nil,
+            redirectUri: nil,
+            nonce: "mock-nonce",
+            walletNonce: nil,
+            state: nil,
+            dcqlQuery: validDcqlQuery,
+            clientMetadata: nil
+        )
+
+        let endpoint = try handler.getResponseEndpoint(authorizationRequest: authorizationRequest)
+
+        XCTAssertEqual(endpoint, "")
+    }
+}

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import JSONWebKey
 @testable import OpenID4VP
 
 final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
@@ -718,23 +719,183 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
     // MARK: - getResponseEndpoint
 
     func testGetResponseEndpointThrowsWhenResponseUriIsNil() throws {
-        let requestWithNoResponseUri = AuthorizationPresentationExchangeRequest(
-            clientId: "client_id",
-            responseType: "vp_token",
-            responseMode: ResponseMode.directPostJwt.rawValue,
-            responseUri: nil,
-            redirectUri: nil,
-            nonce: "nonce",
-            walletNonce: nil,
-            state: "state",
-            presentationDefinition: mockPresentationDefinitionObject,
-            clientMetadata: mockClientMetadataSpecVersionDraft23[.directPostJwt]
-        )
-
-        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getResponseEndpoint(authorizationRequest: requestWithNoResponseUri)) { error in
+        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getResponseEndpoint(authorizationRequestParameters: [:])) { error in
             assertOpenID4VPException(
                 error,
-                expectedMessage: "response_uri is required in authorization request for response mode 'direct_post.jwt'",
+                expectedMessage: "Missing Input: response_uri param is required",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    // MARK: - dispatchInfo-based method tests
+
+    private let encKeyJson: [String: Any] = [
+        "kty": "OKP",
+        "crv": "X25519",
+        "use": "enc",
+        "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+        "alg": "ECDH-ES",
+        "kid": "ed-key1"
+    ]
+
+    private func makeEncryptionSpec() throws -> ResponseEncryptionSpecification {
+        let jwk = try JSONDecoder().decode(JWK.self, from: JSONSerialization.data(withJSONObject: encKeyJson))
+        return ResponseEncryptionSpecification(
+            keyEncryptionAlg: "ECDH-ES",
+            contentEncryptionAlg: "A256GCM",
+            verifierPublicKey: jwk
+        )
+    }
+
+    private func makeJwtDispatchInfo(includeEncryption: Bool = true, state: String? = "state") throws -> ResponseDispatchInfo {
+        ResponseDispatchInfo(
+            responseMode: ResponseMode.directPostJwt.rawValue,
+            nonce: "auth-nonce",
+            walletNonce: "wallet-nonce",
+            state: state,
+            clientId: "client_id",
+            responseUrl: responseUri,
+            responseEncryptionSpecification: includeEncryption ? try makeEncryptionSpec() : nil
+        )
+    }
+
+    func testGetAuthorizationErrorResponseWithDispatchInfoReturnsEncryptedResponse() throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        let errorResponse = AuthorizationErrorResponse(error: "invalid_request", errorDescription: "Bad request", state: "err-state")
+
+        let result = try handler.getAuthorizationErrorResponse(
+            dispatchInfo: try makeJwtDispatchInfo(),
+            authorizationResponse: errorResponse
+        )
+
+        XCTAssertEqual(result.keys.count, 1)
+        XCTAssertNotNil(result["response"], "Error response should be encrypted for direct_post.jwt")
+        XCTAssertFalse(result["response"]!.isEmpty)
+        XCTAssertTrue(result["response"]!.contains("."), "Expected a JWE compact serialization (dots)")
+        XCTAssertNil(result["error"])
+        XCTAssertNil(result["error_description"])
+    }
+
+    func testGetAuthorizationErrorResponseWithDispatchInfoReturnsPlainMapWhenEncryptionSpecIsMissing() throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        let errorResponse = AuthorizationErrorResponse(error: "access_denied", errorDescription: "User denied", state: nil)
+
+        let result = try handler.getAuthorizationErrorResponse(
+            dispatchInfo: try makeJwtDispatchInfo(includeEncryption: false),
+            authorizationResponse: errorResponse
+        )
+
+        XCTAssertEqual(result["error"], "access_denied")
+        XCTAssertEqual(result["error_description"], "User denied")
+        XCTAssertNil(result["state"])
+        XCTAssertNil(result["response"], "Should not be encrypted when encryption spec is absent")
+    }
+
+    func testGetAuthorizationResponseWithDispatchInfoReturnsEncryptedResponse() throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        let authorizationResponse = AuthorizationResponse.presentationExchange(
+            vpToken: mockVPTokens,
+            presentationSubmission: mockPresentationSubmission,
+            state: "state"
+        )
+
+        let result = try handler.getAuthorizationResponse(
+            dispatchInfo: try makeJwtDispatchInfo(),
+            authorizationResponse: authorizationResponse
+        )
+
+        XCTAssertEqual(result.keys.count, 1)
+        XCTAssertNotNil(result["response"])
+        XCTAssertFalse(result["response"]!.isEmpty)
+        XCTAssertTrue(result["response"]!.contains("."), "Expected a JWE compact serialization (dots)")
+    }
+
+    func testGetAuthorizationResponseWithDispatchInfoThrowsWhenEncryptionSpecIsMissing() throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        let authorizationResponse = AuthorizationResponse.presentationExchange(
+            vpToken: mockVPTokens,
+            presentationSubmission: mockPresentationSubmission,
+            state: "state"
+        )
+
+        XCTAssertThrowsError(try handler.getAuthorizationResponse(
+            dispatchInfo: try makeJwtDispatchInfo(includeEncryption: false),
+            authorizationResponse: authorizationResponse
+        )) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "responseEncryptionSpecification is required for response mode 'direct_post.jwt'",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testSendAuthorizationErrorWithDispatchInfoPostsEncryptedResponseToUrl() async throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        mockNetworkManager.clearResponses()
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "error acknowledged")
+
+        let errorResponse = AuthorizationErrorResponse(error: "invalid_scope", errorDescription: "Bad scope", state: "s1")
+
+        let result = try await handler.sendAuthorizationError(
+            dispatchInfo: try makeJwtDispatchInfo(),
+            authorizationResponse: errorResponse,
+            networkManager: mockNetworkManager
+        )
+
+        let recorded = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertEqual(recorded?.requestMethod, .post)
+        XCTAssertEqual(recorded?.requestBody?.keys.count, 1)
+        XCTAssertNotNil(recorded?.requestBody?["response"], "Error response should be encrypted for direct_post.jwt")
+        XCTAssertNil(recorded?.requestBody?["error"])
+        assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: recorded?.requestHeaders)
+        XCTAssertEqual(result.body, "error acknowledged")
+    }
+
+    func testSendAuthorizationResponseWithDispatchInfoPostsEncryptedResponseToUrl() async throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        mockNetworkManager.clearResponses()
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "response received")
+
+        let authorizationResponse = AuthorizationResponse.presentationExchange(
+            vpToken: mockVPTokens,
+            presentationSubmission: mockPresentationSubmission,
+            state: "state"
+        )
+
+        let result = try await handler.sendAuthorizationResponse(
+            dispatchInfo: try makeJwtDispatchInfo(),
+            authorizationResponse: authorizationResponse,
+            networkManager: mockNetworkManager
+        )
+
+        let recorded = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertEqual(recorded?.requestMethod, .post)
+        XCTAssertEqual(recorded?.requestBody?.keys.count, 1)
+        XCTAssertNotNil(recorded?.requestBody?["response"])
+        assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: recorded?.requestHeaders)
+        XCTAssertEqual(result.body, "response received")
+    }
+
+    func testSetResponseUrlReturnsResponseUriForDirectPostJwt() throws {
+        let handler = DirectPostJwtResponseModeHandler()
+        let responseUrl = try handler.setResponseUrl(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com/callback"
+        ])
+
+        XCTAssertEqual(responseUrl, "https://mock-verifier.com/callback")
+    }
+
+    func testSetResponseUrlThrowsForInvalidUriForDirectPostJwt() throws {
+        let handler = DirectPostJwtResponseModeHandler()
+
+        XCTAssertThrowsError(try handler.setResponseUrl(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: "invalid-uri"
+        ])) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "response_uri data is not valid",
                 expectedCode: OpenID4VPErrorCodes.invalidRequest
             )
         }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -766,7 +766,8 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
 
         let result = try handler.getAuthorizationErrorResponse(
             dispatchInfo: try makeJwtDispatchInfo(),
-            authorizationResponse: errorResponse
+            authorizationResponse: errorResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23)
         )
 
         XCTAssertEqual(result.keys.count, 1)
@@ -783,7 +784,8 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
 
         let result = try handler.getAuthorizationErrorResponse(
             dispatchInfo: try makeJwtDispatchInfo(includeEncryption: false),
-            authorizationResponse: errorResponse
+            authorizationResponse: errorResponse,
+            authorizationRequest: nil
         )
 
         XCTAssertEqual(result["error"], "access_denied")
@@ -802,7 +804,8 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
 
         let result = try handler.getAuthorizationResponse(
             dispatchInfo: try makeJwtDispatchInfo(),
-            authorizationResponse: authorizationResponse
+            authorizationResponse: authorizationResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23)
         )
 
         XCTAssertEqual(result.keys.count, 1)
@@ -821,7 +824,8 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
 
         XCTAssertThrowsError(try handler.getAuthorizationResponse(
             dispatchInfo: try makeJwtDispatchInfo(includeEncryption: false),
-            authorizationResponse: authorizationResponse
+            authorizationResponse: authorizationResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23)
         )) { error in
             assertOpenID4VPException(
                 error,
@@ -841,6 +845,7 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
         let result = try await handler.sendAuthorizationError(
             dispatchInfo: try makeJwtDispatchInfo(),
             authorizationResponse: errorResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23),
             networkManager: mockNetworkManager
         )
 
@@ -867,6 +872,7 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
         let result = try await handler.sendAuthorizationResponse(
             dispatchInfo: try makeJwtDispatchInfo(),
             authorizationResponse: authorizationResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23),
             networkManager: mockNetworkManager
         )
 

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -742,8 +742,8 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
     private func makeEncryptionSpec() throws -> ResponseEncryptionSpecification {
         let jwk = try JSONDecoder().decode(JWK.self, from: JSONSerialization.data(withJSONObject: encKeyJson))
         return ResponseEncryptionSpecification(
-            keyEncryptionAlg: "ECDH-ES",
-            contentEncryptionAlg: "A256GCM",
+            keyEncryptionAlg: EncryptionAlgorithm(rawValue: "ECDH-ES")!,
+            contentEncryptionAlg: EncryptionMethod(rawValue: "A256GCM")!,
             verifierPublicKey: jwk
         )
     }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -375,109 +375,6 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
         }
     }
 
-    func testThrowErrorWhenV1ClientMetadataEncDoesNotContainSupportedValue() throws {
-        let invalidClientMetadataV1: [String: Any] = [
-            "authorization_encrypted_response_alg": "ECDH-ES",
-            "encrypted_response_enc_values_supported": ["A128GCM"],
-            "jwks": [
-                "keys": [[
-                    "kty": "OKP",
-                    "crv": "X25519",
-                    "use": "enc",
-                    "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-                    "alg": "ECDH-ES",
-                    "kid": "ed-key1"
-                ]]
-            ],
-            "vp_formats_supported": ["ldp_vc": ["proof_type_values": ["Ed25519Signature2020"]]]
-        ]
-        let v1Request = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .v1)
-        let authorizationResponse = AuthorizationResponse.presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
-        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getAuthorizationResponse(authorizationRequest: AuthorizationDcqlRequest(clientId: v1Request.clientId, responseType: v1Request.responseType, responseMode: v1Request.responseMode, responseUri: v1Request.responseUri, redirectUri: v1Request.redirectUri, nonce: v1Request.nonce, walletNonce: v1Request.walletNonce, state: v1Request.state, dcqlQuery: validDcqlQuery, clientMetadata: createInstance(invalidClientMetadataV1, as: ClientMetadata.self)), authorizationResponse: authorizationResponse, walletNonce: "mock-nonce", walletConfig: walletConfig)) { error in
-            assertOpenID4VPException(error, expectedMessage: "Unsupported content encryption algorithm", expectedCode: OpenID4VPErrorCodes.invalidRequest)
-        }
-    }
-    
-    func testGetAuthorizationResponseThrowsWhenV1ClientMetadataIsNil() throws {
-        let v1Request = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .v1)
-        let requestWithNilMetadata = AuthorizationDcqlRequest(
-            clientId: v1Request.clientId,
-            responseType: v1Request.responseType,
-            responseMode: v1Request.responseMode,
-            responseUri: v1Request.responseUri,
-            redirectUri: v1Request.redirectUri,
-            nonce: v1Request.nonce,
-            walletNonce: v1Request.walletNonce,
-            state: v1Request.state,
-            dcqlQuery: validDcqlQuery,
-            clientMetadata: nil
-        )
-        let authorizationResponse = AuthorizationResponse.presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
-
-        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getAuthorizationResponse(authorizationRequest: requestWithNilMetadata, authorizationResponse: authorizationResponse, walletNonce: "mock-nonce", walletConfig: walletConfig)) { error in
-            assertOpenID4VPException(error, expectedMessage: "client_metadata must be present for given response mode", expectedCode: OpenID4VPErrorCodes.invalidRequest)
-        }
-    }
-
-    func testGetAuthorizationResponseThrowsWhenV1ClientMetadataHasNoJwks() throws {
-        let clientMetadataWithoutJwks: [String: Any] = [
-            "encrypted_response_enc_values_supported": ["A256GCM"],
-            "vp_formats_supported": ["ldp_vc": ["proof_type_values": ["Ed25519Signature2020"]]]
-        ]
-        let v1Request = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .v1)
-        let requestWithNoJwks = AuthorizationDcqlRequest(
-            clientId: v1Request.clientId,
-            responseType: v1Request.responseType,
-            responseMode: v1Request.responseMode,
-            responseUri: v1Request.responseUri,
-            redirectUri: v1Request.redirectUri,
-            nonce: v1Request.nonce,
-            walletNonce: v1Request.walletNonce,
-            state: v1Request.state,
-            dcqlQuery: validDcqlQuery,
-            clientMetadata: createInstance(clientMetadataWithoutJwks, as: ClientMetadata.self)
-        )
-        let authorizationResponse = AuthorizationResponse.presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
-
-        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getAuthorizationResponse(authorizationRequest: requestWithNoJwks, authorizationResponse: authorizationResponse, walletNonce: "mock-nonce", walletConfig: walletConfig)) { error in
-            assertOpenID4VPException(error, expectedMessage: "Missing Input: client_metadata->jwks param is required", expectedCode: OpenID4VPErrorCodes.invalidRequest)
-        }
-    }
-
-    func testGetAuthorizationResponseThrowsWhenV1EncryptionKeyHasNoAlgorithm() throws {
-        let clientMetadataWithKeyWithoutAlg: [String: Any] = [
-            "encrypted_response_enc_values_supported": ["A256GCM"],
-            "jwks": [
-                "keys": [[
-                    "kty": "OKP",
-                    "crv": "X25519",
-                    "use": "enc",
-                    "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-                    "kid": "ed-key1"
-                ]]
-            ],
-            "vp_formats_supported": ["ldp_vc": ["proof_type_values": ["Ed25519Signature2020"]]]
-        ]
-        let v1Request = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .v1)
-        let requestWithKeyWithoutAlg = AuthorizationDcqlRequest(
-            clientId: v1Request.clientId,
-            responseType: v1Request.responseType,
-            responseMode: v1Request.responseMode,
-            responseUri: v1Request.responseUri,
-            redirectUri: v1Request.redirectUri,
-            nonce: v1Request.nonce,
-            walletNonce: v1Request.walletNonce,
-            state: v1Request.state,
-            dcqlQuery: validDcqlQuery,
-            clientMetadata: createInstance(clientMetadataWithKeyWithoutAlg, as: ClientMetadata.self)
-        )
-        let authorizationResponse = AuthorizationResponse.presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
-
-        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getAuthorizationResponse(authorizationRequest: requestWithKeyWithoutAlg, authorizationResponse: authorizationResponse, walletNonce: "mock-nonce", walletConfig: walletConfig)) { error in
-            assertOpenID4VPException(error, expectedMessage: "No jwk matching the specified algorithm found for encryption", expectedCode: OpenID4VPErrorCodes.invalidRequest)
-        }
-    }
-
     // MARK: - getVerifierPublicKeyForEncryption tests
 
     func testGetVerifierPublicKeyForEncryptionReturnsDraft23EncKey() throws {
@@ -568,77 +465,6 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
                 expectedMessage: "No jwk matching the specified algorithm found for encryption",
                 expectedCode: OpenID4VPErrorCodes.invalidRequest
             )
-        }
-    }
-
-    /// Send authorization response tests
-
-    func testSendAuthorizationResponseForDirectPostJwtResponseMode() async throws {
-        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "Response has been shared successfully here.")
-        let authorizationResponse: AuthorizationResponse = AuthorizationResponse.presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
-
-        let draft23Request = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23)
-        let presentationExchangeAuthorizationResponseResult = try await directPostJwtResponseModeHandler.sendAuthorizationResponse(authorizationRequest: draft23Request, authorizationResponse: authorizationResponse, url: draft23Request.responseUri!, networkManager: mockNetworkManager, producerInfo: "mock-nonce", recipientInfo: "verifier-nonce", walletConfig: walletConfig)
-        let draft23RecordedRequest = mockNetworkManager.recordedRequests[responseUri]
-        XCTAssertEqual(HttpMethod.post, draft23RecordedRequest?.requestMethod)
-        XCTAssertEqual(1, draft23RecordedRequest?.requestBody?.keys.count)
-        XCTAssertTrue(draft23RecordedRequest?.requestBody?.keys.allSatisfy(["response"].contains(_:)) == true)
-        assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: draft23RecordedRequest?.requestHeaders)
-        XCTAssertEqual("Response has been shared successfully here.", presentationExchangeAuthorizationResponseResult.body)
-
-        mockNetworkManager.clearResponses()
-        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "Response has been shared successfully here.")
-
-        let v1Request = getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .v1)
-        let dcqlAuthorizationResult = try await directPostJwtResponseModeHandler.sendAuthorizationResponse(authorizationRequest: v1Request, authorizationResponse: authorizationResponse, url: v1Request.responseUri!, networkManager: mockNetworkManager, producerInfo: "tHwahwI6M5_Cd_Sj5k2_Aw", recipientInfo: "_G6UkKgcsUPFlHAbzUMerA", walletConfig: walletConfig)
-        let v1RecordedRequest = mockNetworkManager.recordedRequests[responseUri]
-        XCTAssertEqual(HttpMethod.post, v1RecordedRequest?.requestMethod)
-        XCTAssertEqual(1, v1RecordedRequest?.requestBody?.keys.count)
-        XCTAssertTrue(v1RecordedRequest?.requestBody?.keys.allSatisfy(["response"].contains(_:)) == true)
-        assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: v1RecordedRequest?.requestHeaders)
-        XCTAssertEqual("Response has been shared successfully here.", dcqlAuthorizationResult.body)
-    }
-
-    func testShouldReturnEncryptedResponseForSuccessAuthorizationResponse() throws {
-        let handler = DirectPostJwtResponseModeHandler()
-        let authorizationResponse = AuthorizationResponse.presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "test-state")
-
-        let presentationExchangeAuthorizationResponseResult = try handler.getAuthorizationResponse(authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .draft23), authorizationResponse: authorizationResponse, walletNonce: "mock-nonce", walletConfig: walletConfig)
-        XCTAssertEqual(1, presentationExchangeAuthorizationResponseResult.keys.count)
-        XCTAssertNotNil(presentationExchangeAuthorizationResponseResult["response"])
-        XCTAssertFalse(presentationExchangeAuthorizationResponseResult["response"]!.isEmpty)
-        XCTAssertTrue(presentationExchangeAuthorizationResponseResult["response"]!.contains("."))
-
-        let dcqlAuthorizationResult = try handler.getAuthorizationResponse(authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: .v1), authorizationResponse: authorizationResponse, walletNonce: "mock-nonce", walletConfig: walletConfig)
-        XCTAssertEqual(1, dcqlAuthorizationResult.keys.count)
-        XCTAssertNotNil(dcqlAuthorizationResult["response"])
-        XCTAssertFalse(dcqlAuthorizationResult["response"]!.isEmpty)
-        XCTAssertTrue(dcqlAuthorizationResult["response"]!.contains("."))
-    }
-
-    func testGetAuthorizationResponseShouldReturnPlainErrorMapWhenErrorResponseGiven() throws {
-        let handler = DirectPostJwtResponseModeHandler()
-        let errorResponse = AuthorizationErrorResponse(error: "invalid_request", errorDescription: "something went wrong", state: "error-state")
-
-        for specVersion: SpecVersion in [.draft23, .v1] {
-            let result = try handler.getAuthorizationErrorResponse(authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: specVersion), authorizationResponse: errorResponse, walletNonce: "mock-nonce")
-            XCTAssertEqual(result["error"], "invalid_request")
-            XCTAssertEqual(result["error_description"], "something went wrong")
-            XCTAssertEqual(result["state"], "error-state")
-            XCTAssertNil(result["response"])
-        }
-    }
-
-    func testGetAuthorizationResponseShouldReturnPlainErrorMapWhenErrorResponseGivenAndStateIsNil() throws {
-        let handler = DirectPostJwtResponseModeHandler()
-        let errorResponse = AuthorizationErrorResponse(error: "invalid_request", errorDescription: "something went wrong", state: nil)
-
-        for specVersion: SpecVersion in [.draft23, .v1] {
-            let result = try handler.getAuthorizationErrorResponse(authorizationRequest: getMockAuthorizationRequest(responseMode: .directPostJwt, specVersion: specVersion), authorizationResponse: errorResponse, walletNonce: "mock-nonce")
-            XCTAssertEqual(result["error"], "invalid_request")
-            XCTAssertEqual(result["error_description"], "something went wrong")
-            XCTAssertNil(result["state"])
-            XCTAssertNil(result["response"])
         }
     }
 
@@ -884,19 +710,19 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
         XCTAssertEqual(result.body, "response received")
     }
 
-    func testSetResponseUrlReturnsResponseUriForDirectPostJwt() throws {
+    func testGetResponseEndpointReturnsResponseUriForDirectPostJwt() throws {
         let handler = DirectPostJwtResponseModeHandler()
-        let responseUrl = try handler.setResponseUrl(authorizationRequestParameters: [
+        let responseUrl = try handler.getResponseEndpoint(authorizationRequestParameters: [
             AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com/callback"
         ])
 
         XCTAssertEqual(responseUrl, "https://mock-verifier.com/callback")
     }
 
-    func testSetResponseUrlThrowsForInvalidUriForDirectPostJwt() throws {
+    func testGetResponseEndpointThrowsForInvalidUriForDirectPostJwt() throws {
         let handler = DirectPostJwtResponseModeHandler()
 
-        XCTAssertThrowsError(try handler.setResponseUrl(authorizationRequestParameters: [
+        XCTAssertThrowsError(try handler.getResponseEndpoint(authorizationRequestParameters: [
             AuthorizationRequestFieldConstants.responseUri: "invalid-uri"
         ])) { error in
             assertOpenID4VPException(

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostJwtResponseModeHandlerTests.swift
@@ -554,37 +554,20 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
         }
     }
 
+    func testGetResponseEndpointThrowsWhenResponseUriIsNonStringType() throws {
+        XCTAssertThrowsError(try directPostJwtResponseModeHandler.getResponseEndpoint(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: 12345
+        ])) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "response_uri data is not valid",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
     // MARK: - dispatchInfo-based method tests
-
-    private let encKeyJson: [String: Any] = [
-        "kty": "OKP",
-        "crv": "X25519",
-        "use": "enc",
-        "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-        "alg": "ECDH-ES",
-        "kid": "ed-key1"
-    ]
-
-    private func makeEncryptionSpec() throws -> ResponseEncryptionSpecification {
-        let jwk = try JSONDecoder().decode(JWK.self, from: JSONSerialization.data(withJSONObject: encKeyJson))
-        return ResponseEncryptionSpecification(
-            keyEncryptionAlg: EncryptionAlgorithm(rawValue: "ECDH-ES")!,
-            contentEncryptionAlg: EncryptionMethod(rawValue: "A256GCM")!,
-            verifierPublicKey: jwk
-        )
-    }
-
-    private func makeJwtDispatchInfo(includeEncryption: Bool = true, state: String? = "state") throws -> ResponseDispatchInfo {
-        ResponseDispatchInfo(
-            responseMode: ResponseMode.directPostJwt.rawValue,
-            nonce: "auth-nonce",
-            walletNonce: "wallet-nonce",
-            state: state,
-            clientId: "client_id",
-            responseUrl: responseUri,
-            responseEncryptionSpecification: includeEncryption ? try makeEncryptionSpec() : nil
-        )
-    }
+    // makeJwtDispatchInfo is provided by the shared makeJwtDispatchInfo() free function in TestUtils.swift
 
     func testGetAuthorizationErrorResponseWithDispatchInfoReturnsEncryptedResponse() throws {
         let handler = DirectPostJwtResponseModeHandler()
@@ -728,6 +711,74 @@ final class DirectPostJwtResponseModeHandlerTests: XCTestCase {
             assertOpenID4VPException(
                 error,
                 expectedMessage: "response_uri data is not valid",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testValidateDraft23ThrowsWhenKeyEncryptionAlgorithmIsUnsupported() throws {
+        let clientMetadataDict: [String: Any] = [
+            "client_name": "Test",
+            "authorization_encrypted_response_alg": "unsupported-alg",
+            "authorization_encrypted_response_enc": "A256GCM",
+            "jwks": [
+                "keys": [[
+                    "kty": "OKP", "crv": "X25519", "use": "enc",
+                    "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+                    "alg": "unsupported-alg", "kid": "ed-key1"
+                ]]
+            ],
+            "vp_formats": [
+                "ldp_vp": [
+                    "proof_type": [
+                        "Ed25519Signature2018",
+                        "Ed25519Signature2020"
+                    ]
+                ]
+            ]
+        ]
+        let clientMetadata = createInstance(clientMetadataDict, as: ClientMetadataDraft23.self)
+
+        XCTAssertThrowsError(
+            try directPostJwtResponseModeHandler.validate(clientMetadata: clientMetadata, walletConfig: walletConfig, shouldValidateWithWalletMetadata: false)
+        ) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Unsupported key encryption algorithm: unsupported-alg",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
+
+    func testValidateDraft23ThrowsWhenContentEncryptionMethodIsUnsupported() throws {
+        let clientMetadataDict: [String: Any] = [
+            "client_name": "Test",
+            "authorization_encrypted_response_alg": "ECDH-ES",
+            "authorization_encrypted_response_enc": "unsupported-enc",
+            "jwks": [
+                "keys": [[
+                    "kty": "OKP", "crv": "X25519", "use": "enc",
+                    "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+                    "alg": "ECDH-ES", "kid": "ed-key1"
+                ]]
+            ],
+            "vp_formats": [
+                "ldp_vp": [
+                    "proof_type": [
+                        "Ed25519Signature2018",
+                        "Ed25519Signature2020"
+                    ]
+                ]
+            ]
+        ]
+        let clientMetadata = createInstance(clientMetadataDict, as: ClientMetadataDraft23.self)
+
+        XCTAssertThrowsError(
+            try directPostJwtResponseModeHandler.validate(clientMetadata: clientMetadata, walletConfig: walletConfig, shouldValidateWithWalletMetadata: false)
+        ) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "Unsupported content encryption algorithm: unsupported-enc",
                 expectedCode: OpenID4VPErrorCodes.invalidRequest
             )
         }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -145,4 +145,143 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
         )
         XCTAssertNil(result)
     }
+
+    // MARK: - dispatchInfo-based method tests
+
+    private func makeDirectPostDispatchInfo(state: String? = "test-state") -> ResponseDispatchInfo {
+        ResponseDispatchInfo(
+            responseMode: ResponseMode.directPost.rawValue,
+            nonce: "auth-nonce",
+            walletNonce: "wallet-nonce",
+            state: state,
+            clientId: "client_id",
+            responseUrl: responseUri,
+            responseEncryptionSpecification: nil
+        )
+    }
+
+    func testGetAuthorizationErrorResponseWithDispatchInfoReturnsPlainMap() throws {
+        let handler = DirectPostResponseModeHandler()
+        let errorResponse = AuthorizationErrorResponse(
+            error: "invalid_request",
+            errorDescription: "Something went wrong",
+            state: "err-state"
+        )
+
+        let result = try handler.getAuthorizationErrorResponse(
+            dispatchInfo: makeDirectPostDispatchInfo(),
+            authorizationResponse: errorResponse
+        )
+
+        XCTAssertEqual(result["error"], "invalid_request")
+        XCTAssertEqual(result["error_description"], "Something went wrong")
+        XCTAssertEqual(result["state"], "err-state")
+        XCTAssertEqual(result.keys.count, 3)
+    }
+
+    func testGetAuthorizationErrorResponseWithDispatchInfoOmitsStateWhenNil() throws {
+        let handler = DirectPostResponseModeHandler()
+        let errorResponse = AuthorizationErrorResponse(error: "access_denied", errorDescription: "User denied", state: nil)
+
+        let result = try handler.getAuthorizationErrorResponse(
+            dispatchInfo: makeDirectPostDispatchInfo(),
+            authorizationResponse: errorResponse
+        )
+
+        XCTAssertEqual(result["error"], "access_denied")
+        XCTAssertEqual(result["error_description"], "User denied")
+        XCTAssertNil(result["state"])
+    }
+
+    func testGetAuthorizationResponseWithDispatchInfoReturnsPlainMap() throws {
+        let handler = DirectPostResponseModeHandler()
+        let authorizationResponse = AuthorizationResponse.presentationExchange(
+            vpToken: mockVPTokens,
+            presentationSubmission: mockPresentationSubmission,
+            state: "sample-state"
+        )
+
+        let result = try handler.getAuthorizationResponse(
+            dispatchInfo: makeDirectPostDispatchInfo(),
+            authorizationResponse: authorizationResponse
+        )
+
+        XCTAssertNotNil(result["vp_token"])
+        XCTAssertNotNil(result["presentation_submission"])
+        XCTAssertEqual(result["state"], "sample-state")
+        XCTAssertEqual(result.keys.count, 3)
+    }
+
+    func testSendAuthorizationErrorWithDispatchInfoPostsToResponseUrl() async throws {
+        let handler = DirectPostResponseModeHandler()
+        mockNetworkManager.clearResponses()
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "error acknowledged")
+
+        let errorResponse = AuthorizationErrorResponse(error: "invalid_scope", errorDescription: "Bad scope", state: "s1")
+        let dispatchInfo = makeDirectPostDispatchInfo()
+
+        let result = try await handler.sendAuthorizationError(
+            dispatchInfo: dispatchInfo,
+            authorizationResponse: errorResponse,
+            networkManager: mockNetworkManager
+        )
+
+        let recorded = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertEqual(recorded?.requestMethod, .post)
+        XCTAssertEqual(recorded?.requestBody?["error"], "invalid_scope")
+        XCTAssertEqual(recorded?.requestBody?["error_description"], "Bad scope")
+        XCTAssertEqual(recorded?.requestBody?["state"], "s1")
+        assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: recorded?.requestHeaders)
+        XCTAssertEqual(result.body, "error acknowledged")
+    }
+
+    func testSendAuthorizationResponseWithDispatchInfoPostsToResponseUrl() async throws {
+        let handler = DirectPostResponseModeHandler()
+        mockNetworkManager.clearResponses()
+        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "response received")
+
+        let authorizationResponse = AuthorizationResponse.presentationExchange(
+            vpToken: mockVPTokens,
+            presentationSubmission: mockPresentationSubmission,
+            state: "my-state"
+        )
+        let dispatchInfo = makeDirectPostDispatchInfo()
+
+        let result = try await handler.sendAuthorizationResponse(
+            dispatchInfo: dispatchInfo,
+            authorizationResponse: authorizationResponse,
+            networkManager: mockNetworkManager
+        )
+
+        let recorded = mockNetworkManager.recordedRequests[responseUri]
+        XCTAssertEqual(recorded?.requestMethod, .post)
+        XCTAssertNotNil(recorded?.requestBody?["vp_token"])
+        XCTAssertNotNil(recorded?.requestBody?["presentation_submission"])
+        XCTAssertEqual(recorded?.requestBody?["state"], "my-state")
+        assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: recorded?.requestHeaders)
+        XCTAssertEqual(result.body, "response received")
+    }
+
+    func testSetResponseUrlReturnsResponseUriForDirectPost() throws {
+        let handler = DirectPostResponseModeHandler()
+        let responseUrl = try handler.setResponseUrl(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com/callback"
+        ])
+
+        XCTAssertEqual(responseUrl, "https://mock-verifier.com/callback")
+    }
+
+    func testSetResponseUrlThrowsForInvalidUriForDirectPost() throws {
+        let handler = DirectPostResponseModeHandler()
+
+        XCTAssertThrowsError(try handler.setResponseUrl(authorizationRequestParameters: [
+            AuthorizationRequestFieldConstants.responseUri: "invalid-uri"
+        ])) { error in
+            assertOpenID4VPException(
+                error,
+                expectedMessage: "response_uri data is not valid",
+                expectedCode: OpenID4VPErrorCodes.invalidRequest
+            )
+        }
+    }
 }

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -170,7 +170,8 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
 
         let result = try handler.getAuthorizationErrorResponse(
             dispatchInfo: makeDirectPostDispatchInfo(),
-            authorizationResponse: errorResponse
+            authorizationResponse: errorResponse,
+            authorizationRequest: nil
         )
 
         XCTAssertEqual(result["error"], "invalid_request")
@@ -185,7 +186,8 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
 
         let result = try handler.getAuthorizationErrorResponse(
             dispatchInfo: makeDirectPostDispatchInfo(),
-            authorizationResponse: errorResponse
+            authorizationResponse: errorResponse,
+            authorizationRequest: nil
         )
 
         XCTAssertEqual(result["error"], "access_denied")
@@ -203,7 +205,8 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
 
         let result = try handler.getAuthorizationResponse(
             dispatchInfo: makeDirectPostDispatchInfo(),
-            authorizationResponse: authorizationResponse
+            authorizationResponse: authorizationResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPost)
         )
 
         XCTAssertNotNil(result["vp_token"])
@@ -223,6 +226,7 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
         let result = try await handler.sendAuthorizationError(
             dispatchInfo: dispatchInfo,
             authorizationResponse: errorResponse,
+            authorizationRequest: nil,
             networkManager: mockNetworkManager
         )
 
@@ -250,6 +254,7 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
         let result = try await handler.sendAuthorizationResponse(
             dispatchInfo: dispatchInfo,
             authorizationResponse: authorizationResponse,
+            authorizationRequest: getMockAuthorizationRequest(responseMode: .directPost),
             networkManager: mockNetworkManager
         )
 

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -21,68 +21,6 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
         XCTAssertNoThrow(try directPostAuthorizationResponseModeHandler.validate(clientMetadata: mockClientMetadataSpecVersionDraft23[.directPost], walletConfig: walletConfig, shouldValidateWithWalletMetadata: true))
     }
 
-    func testSendAuthorizationResponseForDirectPostResponseMode() async throws {
-        let directPostAuthorizationResponseModeHandler = DirectPostResponseModeHandler()
-        let authorizationResponse: AuthorizationResponse = .presentationExchange(vpToken: mockVPTokens, presentationSubmission: mockPresentationSubmission, state: "state")
-        mockNetworkManager.clearResponses()
-        mockNetworkManager.setMockResponse(for: responseUri, responseBody: "Response has been shared successfully here.")
-
-        do {
-            let result = try await directPostAuthorizationResponseModeHandler.sendAuthorizationResponse(authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode, authorizationResponse: authorizationResponse, url: mockAuthorizationRequestObjectWithDirectPostResponseMode.responseUri!, networkManager: mockNetworkManager,
-                                                                                                        producerInfo: "mock-nonce",
-                                                                                                        recipientInfo: "verifier-nonce",
-                                                                                                        walletConfig: walletConfig)
-
-            let recordedRequest = mockNetworkManager.recordedRequests[responseUri]
-            XCTAssertEqual(HttpMethod.post, recordedRequest?.requestMethod)
-            XCTAssertTrue(recordedRequest?.requestBody?.keys.count == 3)
-            XCTAssertTrue((recordedRequest?.requestBody?.keys.allSatisfy(["vp_token", "presentation_submission", "state"].contains(_:))) != nil)
-            assertDictionariesEqual(expected: ["Content-Type": ContentTypes.applicationFormUrlEncoded.rawValue], actual: recordedRequest?.requestHeaders)
-            XCTAssertEqual("Response has been shared successfully here.", result.body)
-        }
-    }
-    
-    func testShouldReturnGetAuthorizationSuccessResponseSuccesfully() throws {
-        let handler = DirectPostResponseModeHandler()
-
-        let authorizationResponse: AuthorizationResponse = AuthorizationResponse.presentationExchange(
-            vpToken: mockVPTokens,
-            presentationSubmission: mockPresentationSubmission,
-            state: "sample-state"
-        )
-
-        let result = try handler.getAuthorizationResponse(
-            authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode,
-            authorizationResponse: authorizationResponse,
-            walletNonce: "mock-nonce",
-            walletConfig: walletConfig
-        )
-
-        XCTAssertEqual(result["state"], "sample-state")
-        XCTAssertNotNil(result["vp_token"])
-        XCTAssertNotNil(result["presentation_submission"])
-    }
-
-    func testShouldReturnGetAuthorizationErrorResponseSuccesfully() throws {
-        let handler = DirectPostResponseModeHandler()
-
-        let errorResponse = AuthorizationErrorResponse(
-            error: "invalid_request",
-            errorDescription: "Something went wrong",
-            state: "error-state"
-        )
-
-        let result = handler.getAuthorizationErrorResponse(
-            authorizationRequest: mockAuthorizationRequestObjectWithDirectPostResponseMode,
-            authorizationResponse: errorResponse,
-            walletNonce: "mock-nonce"
-        )
-
-        XCTAssertEqual(result["error"], "invalid_request")
-        XCTAssertEqual(result["error_description"], "Something went wrong")
-        XCTAssertEqual(result["state"], "error-state")
-    }
-
     func testThrowErrorWhenEncryptionRelatedPropertiesAvailableInVerifierMetadata() throws {
         let handler = DirectPostResponseModeHandler()
 
@@ -267,19 +205,19 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
         XCTAssertEqual(result.body, "response received")
     }
 
-    func testSetResponseUrlReturnsResponseUriForDirectPost() throws {
+    func testGetResponseEndpointReturnsResponseUriForDirectPost() throws {
         let handler = DirectPostResponseModeHandler()
-        let responseUrl = try handler.setResponseUrl(authorizationRequestParameters: [
+        let responseUrl = try handler.getResponseEndpoint(authorizationRequestParameters: [
             AuthorizationRequestFieldConstants.responseUri: "https://mock-verifier.com/callback"
         ])
 
         XCTAssertEqual(responseUrl, "https://mock-verifier.com/callback")
     }
 
-    func testSetResponseUrlThrowsForInvalidUriForDirectPost() throws {
+    func testGetResponseEndpointThrowsForInvalidUriForDirectPost() throws {
         let handler = DirectPostResponseModeHandler()
 
-        XCTAssertThrowsError(try handler.setResponseUrl(authorizationRequestParameters: [
+        XCTAssertThrowsError(try handler.getResponseEndpoint(authorizationRequestParameters: [
             AuthorizationRequestFieldConstants.responseUri: "invalid-uri"
         ])) { error in
             assertOpenID4VPException(

--- a/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
+++ b/Tests/OpenID4VPTests/ResponseModeHandler/types/DirectPostResponseModeHandlerTests.swift
@@ -43,7 +43,7 @@ final class DirectPostResponseModeHandlerTests: XCTestCase {
             XCTAssertThrowsError(
                 try handler.validate(clientMetadata: draft23ClientMetadata, walletConfig: walletConfig, shouldValidateWithWalletMetadata: false)
             ) { error in
-                assertOpenID4VPException(error, expectedMessage: "encrypted_response_enc_values_supported or authorization_encrypted_response_alg SHOULD not be present for response mode 'direct_post'", expectedCode: OpenID4VPErrorCodes.invalidRequest)
+                assertOpenID4VPException(error, expectedMessage: "authorization_encrypted_response_enc or authorization_encrypted_response_alg SHOULD not be present for response mode 'direct_post'", expectedCode: OpenID4VPErrorCodes.invalidRequest)
             }
         }
 

--- a/Tests/OpenID4VPTests/TestData/TestUtils.swift
+++ b/Tests/OpenID4VPTests/TestData/TestUtils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JSONWebKey
 @testable import OpenID4VP
 import XCTest
 
@@ -358,5 +359,40 @@ func ldpVC(
         ]
     }
     return data
+}
+
+let jwtDispatchInfoEncKeyJson: [String: Any] = [
+    "kty": "OKP", "crv": "X25519", "use": "enc",
+    "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
+    "alg": "ECDH-ES", "kid": "ed-key1"
+]
+
+func makeJwtDispatchInfo(
+    responseUrl: String = "https://mock-verifier.com",
+    includeEncryption: Bool = true,
+    nonce: String = "tHwahwI6M5_Cd_Sj5k2_Aw",
+    walletNonce: String = "_G6UkKgcsUPFlHAbzUMerA",
+    state: String? = "state"
+) throws -> ResponseDispatchInfo {
+    let encSpec: ResponseEncryptionSpecification?
+    if includeEncryption {
+        let jwk = try JSONDecoder().decode(JWK.self, from: JSONSerialization.data(withJSONObject: jwtDispatchInfoEncKeyJson))
+        encSpec = ResponseEncryptionSpecification(
+            keyEncryptionAlg: EncryptionAlgorithm(rawValue: "ECDH-ES")!,
+            contentEncryptionAlg: EncryptionMethod(rawValue: "A256GCM")!,
+            verifierPublicKey: jwk
+        )
+    } else {
+        encSpec = nil
+    }
+    return ResponseDispatchInfo(
+        responseMode: ResponseMode.directPostJwt.rawValue,
+        nonce: nonce,
+        walletNonce: walletNonce,
+        state: state,
+        clientId: "client_id",
+        responseUrl: responseUrl,
+        responseEncryptionSpecification: encSpec
+    )
 }
 


### PR DESCRIPTION
Fixes: https://github.com/inji/inji-wallet/issues/2526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization request validation and verifier response delivery now use structured dispatch details (response mode, nonce/state, and target endpoint) rather than a single response URL.
  * Enhanced direct_post / direct_post.jwt handling with clearer response encryption-spec behavior, including encrypted responses and encrypted error payloads when configured.
* **Bug Fixes**
  * Improved response endpoint and response mode validation, including stricter handling of incompatible redirect_uri usage.
  * Client metadata validation for direct_post.jwt was simplified to avoid unnecessary failures.
* **Tests**
  * Updated and expanded unit tests to cover dispatch-info flow, endpoint validation, and direct_post.jwt encryption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->