### PR TITLE
redirect to redirect_uri post VP submission if available

### DIFF
--- a/Sources/OpenID4VP/Browser/BrowserRedirectHandler.swift
+++ b/Sources/OpenID4VP/Browser/BrowserRedirectHandler.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+public struct BrowserApp: Identifiable, Equatable, Hashable {
+    public let id: String
+    public let displayName: String
+    public let isDefault: Bool
+
+    let probeURL: URL?
+    let redirectURLBuilder: RedirectURLBuilder
+
+    public static func == (lhs: BrowserApp, rhs: BrowserApp) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    func redirectURL(for redirectUri: String) -> URL? {
+        guard let url = sanitizeRedirectUri(redirectUri).flatMap({ URL(string: $0) }) else {
+            return nil
+        }
+        return redirectURLBuilder.build(from: url)
+    }
+}
+
+enum RedirectURLBuilder: Equatable {
+    case systemDefault
+    case replaceScheme(http: String, https: String)
+    case percentEncodedQuery(prefix: String)
+    case schemeless(prefix: String)
+
+    func build(from url: URL) -> URL? {
+        switch self {
+        case .systemDefault:
+            return url
+
+        case let .replaceScheme(httpReplacement, httpsReplacement):
+            guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let scheme = components.scheme?.lowercased()
+            else { return nil }
+
+            switch scheme {
+            case "http": components.scheme = httpReplacement
+            case "https": components.scheme = httpsReplacement
+            default: return nil
+            }
+            return components.url
+
+        case let .percentEncodedQuery(prefix):
+            guard let encoded = url.absoluteString
+                .addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved)
+            else { return nil }
+            return URL(string: prefix + encoded)
+
+        case let .schemeless(prefix):
+            guard let scheme = url.scheme else { return nil }
+            let schemeless = String(url.absoluteString.dropFirst("\(scheme)://".count))
+            guard !schemeless.isEmpty else { return nil }
+            return URL(string: prefix + schemeless)
+        }
+    }
+}
+
+public extension BrowserApp {
+    static let systemDefault = BrowserApp(
+        id: "default",
+        displayName: "Default browser",
+        isDefault: true,
+        probeURL: nil,
+        redirectURLBuilder: .systemDefault
+    )
+
+    static let chrome = BrowserApp(
+        id: "chrome",
+        displayName: "Chrome",
+        isDefault: false,
+        probeURL: URL(string: "googlechromes://verifier.example.com"),
+        redirectURLBuilder: .replaceScheme(http: "googlechrome", https: "googlechromes")
+    )
+
+    static let firefox = BrowserApp(
+        id: "firefox",
+        displayName: "Firefox",
+        isDefault: false,
+        probeURL: URL(string: "firefox://open-url?url=https%3A%2F%2Fverifier.example.com"),
+        redirectURLBuilder: .percentEncodedQuery(prefix: "firefox://open-url?url=")
+    )
+
+    static let edge = BrowserApp(
+        id: "edge",
+        displayName: "Edge",
+        isDefault: false,
+        probeURL: URL(string: "microsoft-edge-https://verifier.example.com"),
+        redirectURLBuilder: .replaceScheme(http: "microsoft-edge-http", https: "microsoft-edge-https")
+    )
+
+    static let brave = BrowserApp(
+        id: "brave",
+        displayName: "Brave",
+        isDefault: false,
+        probeURL: URL(string: "brave://open-url?url=https%3A%2F%2Fverifier.example.com"),
+        redirectURLBuilder: .percentEncodedQuery(prefix: "brave://open-url?url=")
+    )
+
+    static let opera = BrowserApp(
+        id: "opera",
+        displayName: "Opera Touch",
+        isDefault: false,
+        probeURL: URL(string: "touch-https://verifier.example.com"),
+        redirectURLBuilder: .replaceScheme(http: "touch-http", https: "touch-https")
+    )
+
+    static let duckDuckGo = BrowserApp(
+        id: "duckduckgo",
+        displayName: "DuckDuckGo",
+        isDefault: false,
+        probeURL: URL(string: "ddgQuickLink://verifier.example.com"),
+        redirectURLBuilder: .schemeless(prefix: "ddgQuickLink://")
+    )
+
+    static let knownBrowsers: [BrowserApp] = [chrome, firefox, edge, brave, opera, duckDuckGo]
+}
+
+public protocol BrowserURLOpening {
+    func canOpen(_ url: URL) async -> Bool
+
+    @discardableResult
+    func open(_ url: URL) async -> Bool
+}
+
+public final class BrowserURLOpener: BrowserURLOpening {
+
+    public init() {}
+
+    public func canOpen(_ url: URL) async -> Bool {
+        #if canImport(UIKit)
+        return await MainActor.run { UIApplication.shared.canOpenURL(url) }
+        #elseif canImport(AppKit)
+        return await MainActor.run { NSWorkspace.shared.urlForApplication(toOpen: url) != nil }
+        #else
+        return false
+        #endif
+    }
+
+    @discardableResult
+    public func open(_ url: URL) async -> Bool {
+        #if canImport(UIKit)
+        return await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                UIApplication.shared.open(url, options: [:]) { opened in
+                    continuation.resume(returning: opened)
+                }
+            }
+        }
+        #elseif canImport(AppKit)
+        return await MainActor.run { NSWorkspace.shared.open(url) }
+        #else
+        return false
+        #endif
+    }
+}
+
+public final class BrowserRedirectHandler {
+
+    private static let className = String(describing: BrowserRedirectHandler.self)
+
+    private let urlOpener: BrowserURLOpening
+
+    public init(urlOpener: BrowserURLOpening = BrowserURLOpener()) {
+        self.urlOpener = urlOpener
+    }
+
+    public func getAvailableBrowsers() async -> [BrowserApp] {
+        var availableBrowsers: [BrowserApp] = [.systemDefault]
+
+        for browser in BrowserApp.knownBrowsers {
+            guard let probeURL = browser.probeURL else { continue }
+            if await urlOpener.canOpen(probeURL) {
+                availableBrowsers.append(browser)
+            }
+        }
+
+        return availableBrowsers
+    }
+
+    public func canRedirect(_ verifierResponse: VerifierResponse?) -> Bool {
+        return isNavigableRedirectUri(verifierResponse?.redirectUri)
+    }
+
+    public func shouldOfferBrowserChoice(_ verifierResponse: VerifierResponse?) -> Bool {
+        return isBrowserNavigableRedirectUri(verifierResponse?.redirectUri)
+    }
+
+    @discardableResult
+    public func redirect(
+        _ verifierResponse: VerifierResponse?,
+        using browser: BrowserApp? = nil
+    ) async -> Bool {
+        return await redirect(redirectUri: verifierResponse?.redirectUri, using: browser)
+    }
+
+    @discardableResult
+    public func redirect(
+        redirectUri: String?,
+        using browser: BrowserApp? = nil
+    ) async -> Bool {
+        guard let sanitizedRedirectUri = sanitizeRedirectUri(redirectUri) else {
+            if let redirectUri,
+               !redirectUri.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                OpenID4VPException.warn(
+                    "Verifier returned a redirect_uri that is not an absolute navigable URI. Redirection is skipped.",
+                    className: Self.className
+                )
+            }
+            return false
+        }
+
+        let selectedBrowser = isBrowserNavigableRedirectUri(sanitizedRedirectUri)
+            ? (browser ?? .systemDefault)
+            : .systemDefault
+
+        guard let redirectURL = selectedBrowser.redirectURL(for: sanitizedRedirectUri) else {
+            OpenID4VPException.warn(
+                "Unable to build a \(selectedBrowser.displayName) URL for the redirect_uri returned by the Verifier.",
+                className: Self.className
+            )
+            return false
+        }
+
+        let opened = await urlOpener.open(redirectURL)
+        if !opened {
+            OpenID4VPException.warn(
+                "No application on the device was able to open the redirect_uri returned by the Verifier.",
+                className: Self.className
+            )
+        }
+        return opened
+    }
+}
+
+private extension CharacterSet {
+    static let rfc3986Unreserved = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+}

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -47,6 +47,47 @@ public func isValidUri(_ urlString: String) -> Bool {
     return match.range == range
 }
 
+private let browserSchemes: Set<String> = ["http", "https"]
+
+private let rfc3986UriCharacters = CharacterSet(
+    charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        + "-._~:/?#[]@!$&'()*+,;=%"
+)
+
+private func containsOnlyRfc3986Characters(_ value: String) -> Bool {
+    return value.unicodeScalars.allSatisfy { scalar in
+        !scalar.isASCII || rfc3986UriCharacters.contains(scalar)
+    }
+}
+
+public func sanitizeRedirectUri(_ redirectUri: String?) -> String? {
+    guard let value = redirectUri?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty,
+          containsOnlyRfc3986Characters(value),
+          let components = URLComponents(string: value),
+          let scheme = components.scheme?.lowercased(),
+          !scheme.isEmpty,
+          URL(string: value) != nil
+    else { return nil }
+
+    if browserSchemes.contains(scheme), (components.host ?? "").isEmpty {
+        return nil
+    }
+
+    return value
+}
+
+public func isNavigableRedirectUri(_ redirectUri: String?) -> Bool {
+    return sanitizeRedirectUri(redirectUri) != nil
+}
+
+public func isBrowserNavigableRedirectUri(_ redirectUri: String?) -> Bool {
+    guard let value = sanitizeRedirectUri(redirectUri),
+          let scheme = URLComponents(string: value)?.scheme?.lowercased()
+    else { return false }
+    return browserSchemes.contains(scheme)
+}
+
 func convertToInstance<T: Decodable>(_ dictionary: [String: Any], as type: T.Type) throws -> T {
     let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
     return try JSONDecoder().decode(T.self, from: data)

--- a/Sources/OpenID4VP/Common/Utils.swift
+++ b/Sources/OpenID4VP/Common/Utils.swift
@@ -55,9 +55,7 @@ private let rfc3986UriCharacters = CharacterSet(
 )
 
 private func containsOnlyRfc3986Characters(_ value: String) -> Bool {
-    return value.unicodeScalars.allSatisfy { scalar in
-        !scalar.isASCII || rfc3986UriCharacters.contains(scalar)
-    }
+    return value.unicodeScalars.allSatisfy { rfc3986UriCharacters.contains($0) }
 }
 
 public func sanitizeRedirectUri(_ redirectUri: String?) -> String? {

--- a/Tests/OpenID4VPTests/Browser/BrowserRedirectHandlerTests.swift
+++ b/Tests/OpenID4VPTests/Browser/BrowserRedirectHandlerTests.swift
@@ -96,6 +96,37 @@ final class BrowserRedirectHandlerTests: XCTestCase {
         )
     }
 
+    func testBuildsTheExpectedRedirectUrlForEveryKnownBrowser() async {
+        let redirectUri = "https://client.example.org/cb"
+        let encodedRedirectUri = "https%3A%2F%2Fclient.example.org%2Fcb"
+
+        let cases: [(browser: BrowserApp, probeScheme: String, expectedURL: String)] = [
+            (.chrome, "googlechromes", "googlechromes://client.example.org/cb"),
+            (.firefox, "firefox", "firefox://open-url?url=\(encodedRedirectUri)"),
+            (.edge, "microsoft-edge-https", "microsoft-edge-https://client.example.org/cb"),
+            (.brave, "brave", "brave://open-url?url=\(encodedRedirectUri)"),
+            (.opera, "touch-https", "touch-https://client.example.org/cb"),
+            (.duckDuckGo, "ddgquicklink", "ddgQuickLink://client.example.org/cb")
+        ]
+
+        XCTAssertEqual(cases.count, BrowserApp.knownBrowsers.count)
+
+        for testCase in cases {
+            let urlOpener = MockBrowserURLOpener(installedSchemes: [testCase.probeScheme])
+
+            let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+                .redirect(verifierResponse(redirectUri: redirectUri), using: testCase.browser)
+
+            XCTAssertTrue(redirected, "expected redirection for \(testCase.browser.displayName)")
+            XCTAssertEqual(urlOpener.openedURLs.count, 1, "expected one open for \(testCase.browser.displayName)")
+            XCTAssertEqual(
+                urlOpener.openedURLs.first?.absoluteString.caseInsensitiveCompare(testCase.expectedURL),
+                .orderedSame,
+                "unexpected URL for \(testCase.browser.displayName)"
+            )
+        }
+    }
+
     func testKeepsThePlainHttpSchemeWhenOpeningAnHttpRedirectUri() async {
         let urlOpener = MockBrowserURLOpener(installedSchemes: ["googlechrome"])
 

--- a/Tests/OpenID4VPTests/Browser/BrowserRedirectHandlerTests.swift
+++ b/Tests/OpenID4VPTests/Browser/BrowserRedirectHandlerTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import XCTest
+@testable import OpenID4VP
+
+final class BrowserRedirectHandlerTests: XCTestCase {
+
+    private let redirectUri =
+        "https://client.example.org/cb#response_code=091535f699ea575c7937fa5f0f454aee"
+
+    private func verifierResponse(redirectUri: String?) -> VerifierResponse {
+        return VerifierResponse(
+            statusCode: 200,
+            responseBody: "",
+            redirectUri: redirectUri,
+            additionalParams: nil,
+            headers: [:]
+        )
+    }
+
+    /// Available browsers
+
+    func testOnlyDefaultBrowserIsAvailableWhenNoBrowserSchemeIsDeclared() async {
+        let urlOpener = MockBrowserURLOpener()
+
+        let browsers = await BrowserRedirectHandler(urlOpener: urlOpener).getAvailableBrowsers()
+
+        XCTAssertEqual(browsers.map(\.id), ["default"])
+        XCTAssertTrue(browsers[0].isDefault)
+    }
+
+    func testInstalledBrowsersAreListedAfterTheDefaultBrowser() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["googlechromes", "firefox"])
+
+        let browsers = await BrowserRedirectHandler(urlOpener: urlOpener).getAvailableBrowsers()
+
+        XCTAssertEqual(browsers.map(\.id), ["default", "chrome", "firefox"])
+    }
+
+    func testBrowsersThatAreNotInstalledAreNotListed() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["ddgQuickLink".lowercased()])
+
+        let browsers = await BrowserRedirectHandler(urlOpener: urlOpener).getAvailableBrowsers()
+
+        XCTAssertEqual(browsers.map(\.id), ["default", "duckduckgo"])
+    }
+
+    /// Redirection
+
+    func testRedirectsToTheRedirectUriReturnedByTheVerifier() async {
+        let urlOpener = MockBrowserURLOpener()
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: redirectUri))
+
+        XCTAssertTrue(redirected)
+        XCTAssertEqual(urlOpener.openedURLs.map(\.absoluteString), [redirectUri])
+    }
+
+    func testOpensTheRedirectUriInTheBrowserChosenByTheEndUser() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["googlechromes"])
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: redirectUri), using: .chrome)
+
+        XCTAssertTrue(redirected)
+        XCTAssertEqual(
+            urlOpener.openedURLs.map(\.absoluteString),
+            ["googlechromes://client.example.org/cb#response_code=091535f699ea575c7937fa5f0f454aee"]
+        )
+    }
+
+    func testOpensTheRedirectUriAsAnEncodedQueryParameterForFirefox() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["firefox"])
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: "https://client.example.org/cb?a=1"), using: .firefox)
+
+        XCTAssertTrue(redirected)
+        XCTAssertEqual(
+            urlOpener.openedURLs.map(\.absoluteString),
+            ["firefox://open-url?url=https%3A%2F%2Fclient.example.org%2Fcb%3Fa%3D1"]
+        )
+    }
+
+    func testOpensTheRedirectUriWithoutItsSchemeForDuckDuckGo() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["ddgquicklink"])
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: "https://client.example.org/cb"), using: .duckDuckGo)
+
+        XCTAssertTrue(redirected)
+        XCTAssertEqual(urlOpener.openedURLs.count, 1)
+        XCTAssertEqual(
+            urlOpener.openedURLs.first?.absoluteString.caseInsensitiveCompare("ddgQuickLink://client.example.org/cb"),
+            .orderedSame
+        )
+    }
+
+    func testKeepsThePlainHttpSchemeWhenOpeningAnHttpRedirectUri() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["googlechrome"])
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: "http://client.example.org/cb"), using: .chrome)
+
+        XCTAssertTrue(redirected)
+        XCTAssertEqual(
+            urlOpener.openedURLs.map(\.absoluteString),
+            ["googlechrome://client.example.org/cb"]
+        )
+    }
+
+    func testDoesNotRedirectWhenTheVerifierResponseHasNoRedirectUri() async {
+        let urlOpener = MockBrowserURLOpener()
+        let handler = BrowserRedirectHandler(urlOpener: urlOpener)
+
+        var redirected = await handler.redirect(verifierResponse(redirectUri: nil))
+        XCTAssertFalse(redirected)
+
+        redirected = await handler.redirect(verifierResponse(redirectUri: ""))
+        XCTAssertFalse(redirected)
+
+        XCTAssertTrue(urlOpener.openedURLs.isEmpty)
+    }
+
+    func testDoesNotRedirectWhenTheRedirectUriIsMalformedOrRelative() async {
+        let urlOpener = MockBrowserURLOpener()
+        let handler = BrowserRedirectHandler(urlOpener: urlOpener)
+
+        for uri in ["/cb?response_code=123", "https://client.example.org/a b", "https:///cb"] {
+            let redirected = await handler.redirect(verifierResponse(redirectUri: uri))
+            XCTAssertFalse(redirected, "expected \(uri) to be skipped")
+        }
+
+        XCTAssertTrue(urlOpener.openedURLs.isEmpty)
+    }
+
+    func testReportsFailureWhenNoApplicationCouldOpenTheRedirectUri() async {
+        let urlOpener = MockBrowserURLOpener(openSucceeds: false)
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: redirectUri))
+
+        XCTAssertFalse(redirected)
+        XCTAssertEqual(urlOpener.openedURLs.count, 1)
+    }
+
+    func testLetsTheSystemResolveAHandlerForANonHttpRedirectUri() async {
+        let urlOpener = MockBrowserURLOpener(installedSchemes: ["googlechromes"])
+        let appLink = "mywallet://verifier-callback?response_code=123"
+
+        let redirected = await BrowserRedirectHandler(urlOpener: urlOpener)
+            .redirect(verifierResponse(redirectUri: appLink), using: .chrome)
+
+        XCTAssertTrue(redirected)
+        XCTAssertEqual(urlOpener.openedURLs.map(\.absoluteString), [appLink])
+    }
+
+    /// Redirection capability checks
+
+    func testReportsWhetherTheVerifierResponseCanBeRedirectedTo() {
+        let handler = BrowserRedirectHandler(urlOpener: MockBrowserURLOpener())
+
+        XCTAssertTrue(handler.canRedirect(verifierResponse(redirectUri: redirectUri)))
+        XCTAssertTrue(handler.canRedirect(verifierResponse(redirectUri: "mywallet://callback")))
+        XCTAssertFalse(handler.canRedirect(verifierResponse(redirectUri: nil)))
+        XCTAssertFalse(handler.canRedirect(verifierResponse(redirectUri: "/relative")))
+    }
+
+    func testOffersABrowserChoiceOnlyForHttpRedirectUris() {
+        let handler = BrowserRedirectHandler(urlOpener: MockBrowserURLOpener())
+
+        XCTAssertTrue(handler.shouldOfferBrowserChoice(verifierResponse(redirectUri: redirectUri)))
+        XCTAssertFalse(
+            handler.shouldOfferBrowserChoice(verifierResponse(redirectUri: "mywallet://callback"))
+        )
+        XCTAssertFalse(handler.shouldOfferBrowserChoice(verifierResponse(redirectUri: nil)))
+    }
+}

--- a/Tests/OpenID4VPTests/Browser/BrowserRedirectHandlerTests.swift
+++ b/Tests/OpenID4VPTests/Browser/BrowserRedirectHandlerTests.swift
@@ -96,19 +96,16 @@ final class BrowserRedirectHandlerTests: XCTestCase {
         )
     }
 
-    func testBuildsTheExpectedRedirectUrlForEveryKnownBrowser() async {
-        let redirectUri = "https://client.example.org/cb"
-        let encodedRedirectUri = "https%3A%2F%2Fclient.example.org%2Fcb"
+    /// Lowercases only the scheme, so everything after `://` stays case sensitive.
+    private func normalizingScheme(_ url: String) -> String {
+        guard let separator = url.range(of: "://") else { return url }
+        return url[..<separator.lowerBound].lowercased() + url[separator.lowerBound...]
+    }
 
-        let cases: [(browser: BrowserApp, probeScheme: String, expectedURL: String)] = [
-            (.chrome, "googlechromes", "googlechromes://client.example.org/cb"),
-            (.firefox, "firefox", "firefox://open-url?url=\(encodedRedirectUri)"),
-            (.edge, "microsoft-edge-https", "microsoft-edge-https://client.example.org/cb"),
-            (.brave, "brave", "brave://open-url?url=\(encodedRedirectUri)"),
-            (.opera, "touch-https", "touch-https://client.example.org/cb"),
-            (.duckDuckGo, "ddgquicklink", "ddgQuickLink://client.example.org/cb")
-        ]
-
+    private func assertRedirectURLs(
+        redirectUri: String,
+        cases: [(browser: BrowserApp, probeScheme: String, expectedURL: String)]
+    ) async {
         XCTAssertEqual(cases.count, BrowserApp.knownBrowsers.count)
 
         for testCase in cases {
@@ -120,11 +117,59 @@ final class BrowserRedirectHandlerTests: XCTestCase {
             XCTAssertTrue(redirected, "expected redirection for \(testCase.browser.displayName)")
             XCTAssertEqual(urlOpener.openedURLs.count, 1, "expected one open for \(testCase.browser.displayName)")
             XCTAssertEqual(
-                urlOpener.openedURLs.first?.absoluteString.caseInsensitiveCompare(testCase.expectedURL),
-                .orderedSame,
+                urlOpener.openedURLs.first.map { normalizingScheme($0.absoluteString) },
+                normalizingScheme(testCase.expectedURL),
                 "unexpected URL for \(testCase.browser.displayName)"
             )
         }
+    }
+
+    func testBuildsTheExpectedRedirectUrlForEveryKnownBrowser() async {
+        let encodedRedirectUri = "https%3A%2F%2Fclient.example.org%2Fcb"
+
+        await assertRedirectURLs(
+            redirectUri: "https://client.example.org/cb",
+            cases: [
+                (.chrome, "googlechromes", "googlechromes://client.example.org/cb"),
+                (.firefox, "firefox", "firefox://open-url?url=\(encodedRedirectUri)"),
+                (.edge, "microsoft-edge-https", "microsoft-edge-https://client.example.org/cb"),
+                (.brave, "brave", "brave://open-url?url=\(encodedRedirectUri)"),
+                (.opera, "touch-https", "touch-https://client.example.org/cb"),
+                (.duckDuckGo, "ddgquicklink", "ddgQuickLink://client.example.org/cb")
+            ]
+        )
+    }
+
+    func testBuildsTheExpectedRedirectUrlForEveryKnownBrowserOverHttp() async {
+        let encodedRedirectUri = "http%3A%2F%2Fclient.example.org%2Fcb"
+
+        await assertRedirectURLs(
+            redirectUri: "http://client.example.org/cb",
+            cases: [
+                (.chrome, "googlechrome", "googlechrome://client.example.org/cb"),
+                (.firefox, "firefox", "firefox://open-url?url=\(encodedRedirectUri)"),
+                (.edge, "microsoft-edge-http", "microsoft-edge-http://client.example.org/cb"),
+                (.brave, "brave", "brave://open-url?url=\(encodedRedirectUri)"),
+                (.opera, "touch-http", "touch-http://client.example.org/cb"),
+                (.duckDuckGo, "ddgquicklink", "ddgQuickLink://client.example.org/cb")
+            ]
+        )
+    }
+
+    func testPreservesTheCaseOfThePathAndQueryOfTheRedirectUri() async {
+        let encodedRedirectUri = "https%3A%2F%2Fclient.example.org%2FCb%3FRef%3DAbC"
+
+        await assertRedirectURLs(
+            redirectUri: "https://client.example.org/Cb?Ref=AbC",
+            cases: [
+                (.chrome, "googlechromes", "googlechromes://client.example.org/Cb?Ref=AbC"),
+                (.firefox, "firefox", "firefox://open-url?url=\(encodedRedirectUri)"),
+                (.edge, "microsoft-edge-https", "microsoft-edge-https://client.example.org/Cb?Ref=AbC"),
+                (.brave, "brave", "brave://open-url?url=\(encodedRedirectUri)"),
+                (.opera, "touch-https", "touch-https://client.example.org/Cb?Ref=AbC"),
+                (.duckDuckGo, "ddgquicklink", "ddgQuickLink://client.example.org/Cb?Ref=AbC")
+            ]
+        )
     }
 
     func testKeepsThePlainHttpSchemeWhenOpeningAnHttpRedirectUri() async {

--- a/Tests/OpenID4VPTests/Common/UtilsTest.swift
+++ b/Tests/OpenID4VPTests/Common/UtilsTest.swift
@@ -97,7 +97,11 @@ class UtilsTest : XCTestCase {
             "https:",
             "https:///cb",
             "http://",
-            "https://:8080/cb"
+            "https://:8080/cb",
+            "https://exämple.com/cb",
+            "https://verifier.example.com/cä",
+            "https://verifier.example.com/cb?q=café",
+            "https://verifier.example.com/cb#fragmént"
         ]
 
         for uri in nonNavigableUris {

--- a/Tests/OpenID4VPTests/Common/UtilsTest.swift
+++ b/Tests/OpenID4VPTests/Common/UtilsTest.swift
@@ -58,7 +58,77 @@ class UtilsTest : XCTestCase {
             XCTAssertTrue(isValidUri(url), "expected valid: \(url)")
         }
     }
-    
+
+    /// Validate redirect_uri returned by the Verifier response endpoint tests
+
+    func testSanitizeRedirectUri() {
+        let redirectUri = "https://client.example.org/cb#response_code=091535f699ea575c7937fa5f0f454aee"
+
+        XCTAssertEqual(sanitizeRedirectUri(redirectUri), redirectUri)
+        XCTAssertEqual(
+            sanitizeRedirectUri("https://verifier.example.com/cb?response_code=1234"),
+            "https://verifier.example.com/cb?response_code=1234"
+        )
+        XCTAssertEqual(
+            sanitizeRedirectUri("https://my_verifier.example.com/cb"),
+            "https://my_verifier.example.com/cb"
+        )
+    }
+
+    func testSanitizeRedirectUriTrimsSurroundingWhitespace() {
+        XCTAssertEqual(
+            sanitizeRedirectUri("  https://verifier.example.com/cb  "),
+            "https://verifier.example.com/cb"
+        )
+    }
+
+    func testNonNavigableRedirectUri() {
+        let nonNavigableUris: [String?] = [
+            nil,
+            "",
+            "   ",
+            "/cb?response_code=123",
+            "cb",
+            "//verifier.example.com/cb",
+            "https://verifier.example.com/a b",
+            "ht tp://verifier.example.com",
+            "https://verifier.example.com/cb?next={code}",
+            "https://verifier.example.com/a|b",
+            "https:",
+            "https:///cb",
+            "http://",
+            "https://:8080/cb"
+        ]
+
+        for uri in nonNavigableUris {
+            XCTAssertNil(sanitizeRedirectUri(uri), "expected non navigable: \(String(describing: uri))")
+            XCTAssertFalse(isNavigableRedirectUri(uri), "expected non navigable: \(String(describing: uri))")
+            XCTAssertFalse(isBrowserNavigableRedirectUri(uri), "expected non browser navigable: \(String(describing: uri))")
+        }
+    }
+
+    func testBrowserNavigableRedirectUri() {
+        let browserNavigableUris = [
+            "http://verifier.example.com/cb",
+            "https://verifier.example.com/cb",
+            "HTTPS://verifier.example.com/cb",
+            "Http://verifier.example.com/cb"
+        ]
+
+        for uri in browserNavigableUris {
+            XCTAssertTrue(isNavigableRedirectUri(uri), "expected navigable: \(uri)")
+            XCTAssertTrue(isBrowserNavigableRedirectUri(uri), "expected browser navigable: \(uri)")
+        }
+    }
+
+    func testAppLinkRedirectUriIsNavigableButNotBrowserNavigable() {
+        let appLink = "mywallet://verifier-callback?response_code=123"
+
+        XCTAssertEqual(sanitizeRedirectUri(appLink), appLink)
+        XCTAssertTrue(isNavigableRedirectUri(appLink))
+        XCTAssertFalse(isBrowserNavigableRedirectUri(appLink))
+    }
+
     /// Check if input is JWT tests
     
     func testIsStringIsJWT() {

--- a/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
+++ b/Tests/OpenID4VPTests/Mocks/ProviderMocks.swift
@@ -104,3 +104,28 @@ class MockResponseModeHandler: ResponseModeBasedHandler {
         fatalError("Not needed for unit testing")
     }
 }
+
+final class MockBrowserURLOpener: BrowserURLOpening {
+    var installedSchemes: Set<String>
+    var openSucceeds: Bool
+
+    private(set) var openedURLs: [URL] = []
+    private(set) var probedURLs: [URL] = []
+
+    init(installedSchemes: Set<String> = [], openSucceeds: Bool = true) {
+        self.installedSchemes = installedSchemes
+        self.openSucceeds = openSucceeds
+    }
+
+    func canOpen(_ url: URL) async -> Bool {
+        probedURLs.append(url)
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return installedSchemes.contains(scheme)
+    }
+
+    @discardableResult
+    func open(_ url: URL) async -> Bool {
+        openedURLs.append(url)
+        return openSucceeds
+    }
+}

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -25,6 +25,7 @@ This guide provides detailed information on integrating the OpenID4VP SDK into y
   - [2. User Selection of Credentials and Consent](#2-user-selection-of-credentials-and-consent)
   - [3. Construction of a Verifiable Presentation and Submission to the Verifier](#3-construction-of-a-verifiable-presentation-and-submission-to-the-verifier)
   - [4. Dispatch Error to Verifier](#4-dispatch-errors-to-the-verifier)
+  - [5. Redirect to the Verifier's redirect_uri](#5-redirect-to-the-verifiers-redirect_uri)
 
 ---
 
@@ -36,6 +37,7 @@ This guide provides detailed information on integrating the OpenID4VP SDK into y
     - Provide the validated Authorization Request (Presentation Definition or DCQL query) to the Wallet.
 - Prepare the Verifiable Presentation response by requesting the Wallet to sign the required data.
 - Submit the Authorization Response to the Verifier in accordance with the received presentation request.
+- Redirect the End-User's browser to the `redirect_uri` returned by the Verifier after submission, listing the browsers available on the device for the End-User to choose from.
 
 
 > **Note:** Fetching Verifiable Presentations request via the [`scope`](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-using-scope-parameter-to-re) parameter is not supported by this SDK.
@@ -918,6 +920,76 @@ let verifierResponse: VerifierResponse = try await openID4VP.sendErrorInfoToVeri
 #### Exceptions
 
 * `ErrorDispatchFailure` — Thrown if the error response cannot be successfully delivered to the Verifier.
+
+---
+
+## 5. Redirect to the Verifier's `redirect_uri`
+
+After the Authorization Response has been submitted, the Verifier's Response Endpoint MAY return a `redirect_uri` in its JSON body. As per [OpenID4VP 1.0 Section 8.2](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-8.2):
+
+> `redirect_uri`: OPTIONAL. String containing a URI. When this parameter is present the Wallet MUST redirect the user agent to this URI.
+
+The URI must be opened in the End-User's browser — it must **not** be fetched as a back-channel HTTP request. If the response does not contain a `redirect_uri`, the Wallet is not required to perform any further steps.
+
+`BrowserRedirectHandler` performs this redirection and lists the browsers available on the device so the End-User can choose one.
+
+```swift
+import OpenID4VP
+
+let verifierResponse: VerifierResponse = try await openID4VP.sendVPResponseToVerifier(
+    vpTokenSigningResults: signingResults
+)
+
+let redirectHandler = BrowserRedirectHandler()
+
+if redirectHandler.canRedirect(verifierResponse) {
+    let browsers: [BrowserApp] = await redirectHandler.getAvailableBrowsers()
+    // Render `browsers` and let the End-User pick one, then:
+    await redirectHandler.redirect(verifierResponse, using: selectedBrowser)
+}
+```
+
+The same handler applies to the `VerifierResponse` returned by `sendErrorInfoToVerifier`, since the Response Endpoint may return a `redirect_uri` for Error Responses too.
+
+### Methods
+
+| Method                                        | Returns        | Description                                                                                                                |
+|-----------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| `canRedirect(_:)`                             | `Bool`         | Whether the Verifier returned a `redirect_uri` that is an absolute, navigable URI.                                          |
+| `shouldOfferBrowserChoice(_:)`                | `Bool`         | Whether a browser chooser is meaningful. Only `http(s)` URIs are opened in a browser.                                        |
+| `getAvailableBrowsers()`                      | `[BrowserApp]` | Browsers available on the device, the End-User's default browser first.                                                     |
+| `redirect(_:using:)`                          | `Bool`         | Opens the `redirect_uri`. Pass `nil` as `using` to open the default browser. Returns whether navigation started.             |
+
+**`BrowserApp` Structure**
+
+| Field         | Type     | Description                                                          |
+|---------------|----------|------------------------------------------------------------------------|
+| `id`          | `String` | Stable identifier of the browser, e.g. `chrome`.                      |
+| `displayName` | `String` | Human readable name to show to the End-User, e.g. `Chrome`.           |
+| `isDefault`   | `Bool`   | Whether this entry opens the End-User's default browser.               |
+
+### Detecting third party browsers
+
+iOS does not expose the list of installed browsers. The End-User's default browser is always offered; a third party browser is only detected when your Wallet declares its URL scheme under `LSApplicationQueriesSchemes` in `Info.plist`, otherwise `canOpenURL` always reports `false`.
+
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>googlechromes</string>
+    <string>firefox</string>
+    <string>microsoft-edge-https</string>
+    <string>brave</string>
+    <string>touch-https</string>
+    <string>ddgQuickLink</string>
+</array>
+```
+
+### Behaviour notes
+
+- A `redirect_uri` that is blank, relative or malformed is ignored and `redirect` returns `false`, so a non-conformant Verifier cannot break the flow.
+- Non-`http(s)` absolute URIs (for example `mywallet://callback`) are handed to the application registered for that scheme instead of a browser.
+- **Security:** the `redirect_uri` is chosen by the Verifier, and a non-`http(s)` value launches whatever application is registered for that scheme (e.g. `tel:`, `sms:`, a third-party app's deep link) with the Wallet's implied legitimacy. If your Wallet only interacts with web-based Verifiers, gate the call on `shouldOfferBrowserChoice(verifierResponse)` so that only `http(s)` URIs are ever opened.
+- `BrowserRedirectHandler` accepts a custom `BrowserURLOpening` implementation via its initializer, which is useful in tests.
 
 ---
 


### PR DESCRIPTION
- Adds BrowserRedirectHandler with a catalog of six third-party browsers plus the system default, each with its own URL-rewriting strategy.
- Detects installed browsers via canOpenURL probes; consumers must declare the schemes in LSApplicationQueriesSchemes.
- Mirrors the Kotlin URI validation in Common/Utils.swift, including an explicit RFC 3986 character check.
- Adds 14 tests using a MockBrowserURLOpener added to the existing ProviderMocks.swift.

## Github issue link :
https://github.com/orgs/inji/projects/4/views/24?pane=issue&itemId=217451397&issue=inji%7Cinji-wallet%7C2546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-based redirects for authorization and error responses.
  * Supports browser discovery, optional browser selection, platform-specific URL handling, and asynchronous opening.
  * Added validation for navigable and browser-compatible redirect URIs.

* **Documentation**
  * Added integration guidance for redirect handling, browser configuration, custom openers, and security considerations.

* **Tests**
  * Added coverage for browser discovery, URI validation, redirect transformations, and opening failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->